### PR TITLE
implement feeDelegation

### DIFF
--- a/.openzeppelin/base-sepolia.json
+++ b/.openzeppelin/base-sepolia.json
@@ -817,11 +817,6 @@
       "kind": "transparent"
     },
     {
-      "address": "0x2eB4313e3047845FD07315A51003F1f440780cdD",
-      "txHash": "0x2b7cc48ea7c3ea696e6ec12b415076c8a20564597443ede0ec5856c444d1aff5",
-      "kind": "transparent"
-    },
-    {
       "address": "0xd1BA3DccA820Dd0B784DE653441897029Bf1637d",
       "txHash": "0xa5c4b65fab7b3356dd22a16900be44dff274689ff8c27859ec98e124779f43f5",
       "kind": "transparent"
@@ -838,6 +833,10 @@
     },
     {
       "address": "0x4406b069BDC89CFbB2FACA877a2Fd09bAd256874",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x2eB4313e3047845FD07315A51003F1f440780cdD",
       "kind": "transparent"
     }
   ],
@@ -55488,6 +55487,1187 @@
       "allAddresses": [
         "0x7269Bb28F89b2D3120eE3104e1b2dB9A01621C9a",
         "0xf0dc6E31C04994781d6180A2F3AB4ea854C75b48"
+      ]
+    },
+    "85cf056397642d80d12d07c8b4e9ca19ce23d51c07aba728bf27f871e1bc6d1a": {
+      "address": "0x456C940dddb0bda4e5b24346aee715F498BA5CF0",
+      "txHash": "0x0b7033a2ce28ff43cd09388dc9fcc078fd340a1d3e2596dfaa21db552c52975b",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "assetToken",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:48"
+          },
+          {
+            "label": "taxToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:49"
+          },
+          {
+            "label": "router",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IRouter)13948",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:50"
+          },
+          {
+            "label": "treasury",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_address",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:51"
+          },
+          {
+            "label": "feeRate",
+            "offset": 20,
+            "slot": "3",
+            "type": "t_uint16",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:52"
+          },
+          {
+            "label": "minSwapThreshold",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_uint256",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:53"
+          },
+          {
+            "label": "maxSwapThreshold",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_uint256",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:54"
+          },
+          {
+            "label": "tokenRecipients",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_address,t_struct(TaxRecipient)14241_storage)",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:56"
+          },
+          {
+            "label": "tokenTaxAmounts",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_struct(TaxAmounts)14246_storage)",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:57"
+          },
+          {
+            "label": "bondingV5",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_contract(IBondingV5ForTaxV2)14227",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:59"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(IBondingV5ForTaxV2)14227": {
+            "label": "contract IBondingV5ForTaxV2",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IRouter)13948": {
+            "label": "contract IRouter",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_struct(TaxAmounts)14246_storage)": {
+            "label": "mapping(address => struct AgentTaxV2.TaxAmounts)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(TaxRecipient)14241_storage)": {
+            "label": "mapping(address => struct AgentTaxV2.TaxRecipient)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(TaxAmounts)14246_storage": {
+            "label": "struct AgentTaxV2.TaxAmounts",
+            "members": [
+              {
+                "label": "amountCollected",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "amountSwapped",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(TaxRecipient)14241_storage": {
+            "label": "struct AgentTaxV2.TaxRecipient",
+            "members": [
+              {
+                "label": "tba",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "f79af91663d30034b00799da77091da4e8b3db186816b33b8eaab99de316efe8": {
+      "address": "0xfabA46F16816F1DDA93aEa3Ee096f06369e85d4a",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(IFFactoryV2Minimal)8016",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:95"
+          },
+          {
+            "label": "router",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_contract(IFRouterV3Minimal)8078",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:96"
+          },
+          {
+            "label": "agentFactory",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IAgentFactoryV7Minimal)8143",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:97"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(BondingConfig)2972",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:98"
+          },
+          {
+            "label": "tokenInfo",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_struct(Token)2469_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:100"
+          },
+          {
+            "label": "tokenInfos",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:101"
+          },
+          {
+            "label": "tokenLaunchParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_address,t_struct(LaunchParams)2480_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:107"
+          },
+          {
+            "label": "tokenGradThreshold",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:110"
+          },
+          {
+            "label": "isFeeDelegation",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:112"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)151_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)296_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint8)dyn_storage": {
+            "label": "uint8[]",
+            "numberOfBytes": "32"
+          },
+          "t_contract(BondingConfig)2972": {
+            "label": "contract BondingConfig",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IAgentFactoryV7Minimal)8143": {
+            "label": "contract IAgentFactoryV7Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFFactoryV2Minimal)8016": {
+            "label": "contract IFFactoryV2Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFRouterV3Minimal)8078": {
+            "label": "contract IFRouterV3Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(LaunchParams)2480_storage)": {
+            "label": "mapping(address => struct BondingConfig.LaunchParams)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Token)2469_storage)": {
+            "label": "mapping(address => struct BondingConfig.Token)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Data)2430_storage": {
+            "label": "struct BondingConfig.Data",
+            "members": [
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "ticker",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "supply",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "price",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "marketCap",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "liquidity",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "volume",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "volume24H",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "prevPrice",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "10"
+              },
+              {
+                "label": "lastUpdated",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "11"
+              }
+            ],
+            "numberOfBytes": "384"
+          },
+          "t_struct(LaunchParams)2480_storage": {
+            "label": "struct BondingConfig.LaunchParams",
+            "members": [
+              {
+                "label": "launchMode",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "airdropBips",
+                "type": "t_uint16",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "needAcf",
+                "type": "t_bool",
+                "offset": 3,
+                "slot": "0"
+              },
+              {
+                "label": "antiSniperTaxType",
+                "type": "t_uint8",
+                "offset": 4,
+                "slot": "0"
+              },
+              {
+                "label": "isProject60days",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Token)2469_storage": {
+            "label": "struct BondingConfig.Token",
+            "members": [
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "pair",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "agentToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "data",
+                "type": "t_struct(Data)2430_storage",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "description",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "16"
+              },
+              {
+                "label": "cores",
+                "type": "t_array(t_uint8)dyn_storage",
+                "offset": 0,
+                "slot": "17"
+              },
+              {
+                "label": "image",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "18"
+              },
+              {
+                "label": "twitter",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "19"
+              },
+              {
+                "label": "telegram",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "20"
+              },
+              {
+                "label": "youtube",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "21"
+              },
+              {
+                "label": "website",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "22"
+              },
+              {
+                "label": "trading",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "23"
+              },
+              {
+                "label": "tradingOnUniswap",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "23"
+              },
+              {
+                "label": "applicationId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "24"
+              },
+              {
+                "label": "initialPurchase",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "25"
+              },
+              {
+                "label": "virtualId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "26"
+              },
+              {
+                "label": "launchExecuted",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "27"
+              }
+            ],
+            "numberOfBytes": "896"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      },
+      "allAddresses": [
+        "0xfabA46F16816F1DDA93aEa3Ee096f06369e85d4a",
+        "0xc50a47cB0db8C8329D88b40024e24389b1C92010"
+      ]
+    },
+    "72768d2b9d90eb2ea0ac3816945dd5b56213ba61927759d12ab727159a65bbd0": {
+      "address": "0xc50a47cB0db8C8329D88b40024e24389b1C92010",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(IFFactoryV2Minimal)43546",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:95"
+          },
+          {
+            "label": "router",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_contract(IFRouterV3Minimal)43608",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:96"
+          },
+          {
+            "label": "agentFactory",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IAgentFactoryV7Minimal)43673",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:97"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(BondingConfig)38502",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:98"
+          },
+          {
+            "label": "tokenInfo",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_struct(Token)37999_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:100"
+          },
+          {
+            "label": "tokenInfos",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:101"
+          },
+          {
+            "label": "tokenLaunchParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_address,t_struct(LaunchParams)38010_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:107"
+          },
+          {
+            "label": "tokenGradThreshold",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:110"
+          },
+          {
+            "label": "isFeeDelegation",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:112"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)1512_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)206_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)2531_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint8)dyn_storage": {
+            "label": "uint8[]",
+            "numberOfBytes": "32"
+          },
+          "t_contract(BondingConfig)38502": {
+            "label": "contract BondingConfig",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IAgentFactoryV7Minimal)43673": {
+            "label": "contract IAgentFactoryV7Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFFactoryV2Minimal)43546": {
+            "label": "contract IFFactoryV2Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFRouterV3Minimal)43608": {
+            "label": "contract IFRouterV3Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(LaunchParams)38010_storage)": {
+            "label": "mapping(address => struct BondingConfig.LaunchParams)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Token)37999_storage)": {
+            "label": "mapping(address => struct BondingConfig.Token)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Data)37960_storage": {
+            "label": "struct BondingConfig.Data",
+            "members": [
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "ticker",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "supply",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "price",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "marketCap",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "liquidity",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "volume",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "volume24H",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "prevPrice",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "10"
+              },
+              {
+                "label": "lastUpdated",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "11"
+              }
+            ],
+            "numberOfBytes": "384"
+          },
+          "t_struct(LaunchParams)38010_storage": {
+            "label": "struct BondingConfig.LaunchParams",
+            "members": [
+              {
+                "label": "launchMode",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "airdropBips",
+                "type": "t_uint16",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "needAcf",
+                "type": "t_bool",
+                "offset": 3,
+                "slot": "0"
+              },
+              {
+                "label": "antiSniperTaxType",
+                "type": "t_uint8",
+                "offset": 4,
+                "slot": "0"
+              },
+              {
+                "label": "isProject60days",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Token)37999_storage": {
+            "label": "struct BondingConfig.Token",
+            "members": [
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "pair",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "agentToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "data",
+                "type": "t_struct(Data)37960_storage",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "description",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "16"
+              },
+              {
+                "label": "cores",
+                "type": "t_array(t_uint8)dyn_storage",
+                "offset": 0,
+                "slot": "17"
+              },
+              {
+                "label": "image",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "18"
+              },
+              {
+                "label": "twitter",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "19"
+              },
+              {
+                "label": "telegram",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "20"
+              },
+              {
+                "label": "youtube",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "21"
+              },
+              {
+                "label": "website",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "22"
+              },
+              {
+                "label": "trading",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "23"
+              },
+              {
+                "label": "tradingOnUniswap",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "23"
+              },
+              {
+                "label": "applicationId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "24"
+              },
+              {
+                "label": "initialPurchase",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "25"
+              },
+              {
+                "label": "virtualId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "26"
+              },
+              {
+                "label": "launchExecuted",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "27"
+              }
+            ],
+            "numberOfBytes": "896"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      },
+      "allAddresses": [
+        "0xc50a47cB0db8C8329D88b40024e24389b1C92010",
+        "0xEC5C72c6f4020D63b45c51808916aAfd85c3198F"
       ]
     }
   }

--- a/.openzeppelin/base.json
+++ b/.openzeppelin/base.json
@@ -20348,7 +20348,7 @@
             "label": "router",
             "offset": 0,
             "slot": "2",
-            "type": "t_contract(IRouter)15664",
+            "type": "t_contract(IRouter)58232",
             "contract": "AgentTaxV2",
             "src": "contracts/tax/AgentTaxV2.sol:49"
           },
@@ -20388,7 +20388,7 @@
             "label": "tokenRecipients",
             "offset": 0,
             "slot": "6",
-            "type": "t_mapping(t_address,t_struct(TaxRecipient)17882_storage)",
+            "type": "t_mapping(t_address,t_struct(TaxRecipient)61452_storage)",
             "contract": "AgentTaxV2",
             "src": "contracts/tax/AgentTaxV2.sol:55"
           },
@@ -20396,7 +20396,7 @@
             "label": "tokenTaxAmounts",
             "offset": 0,
             "slot": "7",
-            "type": "t_mapping(t_address,t_struct(TaxAmounts)17887_storage)",
+            "type": "t_mapping(t_address,t_struct(TaxAmounts)61457_storage)",
             "contract": "AgentTaxV2",
             "src": "contracts/tax/AgentTaxV2.sol:56"
           },
@@ -20404,7 +20404,7 @@
             "label": "bondingV5",
             "offset": 0,
             "slot": "8",
-            "type": "t_contract(IBondingV5ForTaxV2)17868",
+            "type": "t_contract(IBondingV5ForTaxV2)61438",
             "contract": "AgentTaxV2",
             "src": "contracts/tax/AgentTaxV2.sol:58"
           }
@@ -20442,7 +20442,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(InitializableStorage)266_storage": {
+          "t_struct(InitializableStorage)1512_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -20482,23 +20482,23 @@
             "label": "uint64",
             "numberOfBytes": "8"
           },
-          "t_contract(IBondingV5ForTaxV2)17868": {
+          "t_contract(IBondingV5ForTaxV2)61438": {
             "label": "contract IBondingV5ForTaxV2",
             "numberOfBytes": "20"
           },
-          "t_contract(IRouter)15664": {
+          "t_contract(IRouter)58232": {
             "label": "contract IRouter",
             "numberOfBytes": "20"
           },
-          "t_mapping(t_address,t_struct(TaxAmounts)17887_storage)": {
+          "t_mapping(t_address,t_struct(TaxAmounts)61457_storage)": {
             "label": "mapping(address => struct AgentTaxV2.TaxAmounts)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_address,t_struct(TaxRecipient)17882_storage)": {
+          "t_mapping(t_address,t_struct(TaxRecipient)61452_storage)": {
             "label": "mapping(address => struct AgentTaxV2.TaxRecipient)",
             "numberOfBytes": "32"
           },
-          "t_struct(TaxAmounts)17887_storage": {
+          "t_struct(TaxAmounts)61457_storage": {
             "label": "struct AgentTaxV2.TaxAmounts",
             "members": [
               {
@@ -20516,7 +20516,7 @@
             ],
             "numberOfBytes": "64"
           },
-          "t_struct(TaxRecipient)17882_storage": {
+          "t_struct(TaxRecipient)61452_storage": {
             "label": "struct AgentTaxV2.TaxRecipient",
             "members": [
               {
@@ -28210,6 +28210,720 @@
               "label": "_owner",
               "type": "t_address",
               "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "21a3ee2477a64ddeb8c5b0de399370c409ec9187487d9d382f8666dd50604d58": {
+      "address": "0x35a30ab13E06098800543E0f33f67C7E8C7d6b10",
+      "txHash": "0x223c51095e341fa2eba44e4c46d276f5053d1fe23f47d994cab83b515964cf58",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(IFFactoryV2Minimal)2487",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:95"
+          },
+          {
+            "label": "router",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_contract(IFRouterV3Minimal)2549",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:96"
+          },
+          {
+            "label": "agentFactory",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IAgentFactoryV7Minimal)2614",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:97"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(BondingConfig)2449",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:98"
+          },
+          {
+            "label": "tokenInfo",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_struct(Token)1930_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:100"
+          },
+          {
+            "label": "tokenInfos",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:101"
+          },
+          {
+            "label": "tokenLaunchParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_address,t_struct(LaunchParams)1941_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:107"
+          },
+          {
+            "label": "tokenGradThreshold",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:110"
+          },
+          {
+            "label": "isFeeDelegation",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:112"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)151_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)296_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint8)dyn_storage": {
+            "label": "uint8[]",
+            "numberOfBytes": "32"
+          },
+          "t_contract(BondingConfig)2449": {
+            "label": "contract BondingConfig",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IAgentFactoryV7Minimal)2614": {
+            "label": "contract IAgentFactoryV7Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFFactoryV2Minimal)2487": {
+            "label": "contract IFFactoryV2Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFRouterV3Minimal)2549": {
+            "label": "contract IFRouterV3Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(LaunchParams)1941_storage)": {
+            "label": "mapping(address => struct BondingConfig.LaunchParams)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Token)1930_storage)": {
+            "label": "mapping(address => struct BondingConfig.Token)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Data)1891_storage": {
+            "label": "struct BondingConfig.Data",
+            "members": [
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "ticker",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "supply",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "price",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "marketCap",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "liquidity",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "volume",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "volume24H",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "prevPrice",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "10"
+              },
+              {
+                "label": "lastUpdated",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "11"
+              }
+            ],
+            "numberOfBytes": "384"
+          },
+          "t_struct(LaunchParams)1941_storage": {
+            "label": "struct BondingConfig.LaunchParams",
+            "members": [
+              {
+                "label": "launchMode",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "airdropBips",
+                "type": "t_uint16",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "needAcf",
+                "type": "t_bool",
+                "offset": 3,
+                "slot": "0"
+              },
+              {
+                "label": "antiSniperTaxType",
+                "type": "t_uint8",
+                "offset": 4,
+                "slot": "0"
+              },
+              {
+                "label": "isProject60days",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Token)1930_storage": {
+            "label": "struct BondingConfig.Token",
+            "members": [
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "pair",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "agentToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "data",
+                "type": "t_struct(Data)1891_storage",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "description",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "16"
+              },
+              {
+                "label": "cores",
+                "type": "t_array(t_uint8)dyn_storage",
+                "offset": 0,
+                "slot": "17"
+              },
+              {
+                "label": "image",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "18"
+              },
+              {
+                "label": "twitter",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "19"
+              },
+              {
+                "label": "telegram",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "20"
+              },
+              {
+                "label": "youtube",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "21"
+              },
+              {
+                "label": "website",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "22"
+              },
+              {
+                "label": "trading",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "23"
+              },
+              {
+                "label": "tradingOnUniswap",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "23"
+              },
+              {
+                "label": "applicationId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "24"
+              },
+              {
+                "label": "initialPurchase",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "25"
+              },
+              {
+                "label": "virtualId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "26"
+              },
+              {
+                "label": "launchExecuted",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "27"
+              }
+            ],
+            "numberOfBytes": "896"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "85cf056397642d80d12d07c8b4e9ca19ce23d51c07aba728bf27f871e1bc6d1a": {
+      "address": "0x700CaF5228920F768B4a0A50c0069b24779FD326",
+      "txHash": "0x06dd510e53979f0e99793592c8b7b398ca9c16c26e393fd7850262af5ca748b2",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "assetToken",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:48"
+          },
+          {
+            "label": "taxToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:49"
+          },
+          {
+            "label": "router",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IRouter)4585",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:50"
+          },
+          {
+            "label": "treasury",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_address",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:51"
+          },
+          {
+            "label": "feeRate",
+            "offset": 20,
+            "slot": "3",
+            "type": "t_uint16",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:52"
+          },
+          {
+            "label": "minSwapThreshold",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_uint256",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:53"
+          },
+          {
+            "label": "maxSwapThreshold",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_uint256",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:54"
+          },
+          {
+            "label": "tokenRecipients",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_address,t_struct(TaxRecipient)4636_storage)",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:56"
+          },
+          {
+            "label": "tokenTaxAmounts",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_struct(TaxAmounts)4641_storage)",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:57"
+          },
+          {
+            "label": "bondingV5",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_contract(IBondingV5ForTaxV2)4622",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:59"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(IBondingV5ForTaxV2)4622": {
+            "label": "contract IBondingV5ForTaxV2",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IRouter)4585": {
+            "label": "contract IRouter",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_struct(TaxAmounts)4641_storage)": {
+            "label": "mapping(address => struct AgentTaxV2.TaxAmounts)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(TaxRecipient)4636_storage)": {
+            "label": "mapping(address => struct AgentTaxV2.TaxRecipient)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(TaxAmounts)4641_storage": {
+            "label": "struct AgentTaxV2.TaxAmounts",
+            "members": [
+              {
+                "label": "amountCollected",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "amountSwapped",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(TaxRecipient)4636_storage": {
+            "label": "struct AgentTaxV2.TaxRecipient",
+            "members": [
+              {
+                "label": "tba",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
               "offset": 0,
               "slot": "0"
             }

--- a/contracts/launchpadv2/BondingV5.sol
+++ b/contracts/launchpadv2/BondingV5.sol
@@ -147,6 +147,25 @@ contract BondingV5 is
         _disableInitializers();
     }
 
+    /// @notice Decode `isFeeDelegation` from optional extension calldata.
+    /// @dev V1 layout: first 32 bytes = `abi.encode(bool isFeeDelegation)` (standard ABI word).
+    ///      Empty `extParams` or length less than 32 ⇒ false. Extra trailing bytes are ignored here so
+    ///      callers can forward-compat append more values after the bool (same encoding rules).
+    ///      Non-canonical bool words (not 0 or 1) ⇒ false.
+    function _decodeIsFeeDelegation(bytes calldata extParams) internal pure returns (bool) {
+        if (extParams.length < 32) {
+            return false;
+        }
+        bytes32 word;
+        assembly ("memory-safe") {
+            word := calldataload(extParams.offset)
+        }
+        uint256 v = uint256(word);
+        if (v == 1) return true;
+        if (v == 0) return false;
+        return false;
+    }
+
     function initialize(
         address factory_,
         address router_,
@@ -162,6 +181,9 @@ contract BondingV5 is
         bondingConfig = BondingConfig(bondingConfig_);
     }
 
+    /// @param extParams_ Optional extension payload. V1: `abi.encode(bool isFeeDelegation)`; use
+    ///         `""` (empty) to default `isFeeDelegation` to false. Future versions may use
+    ///         `abi.encode(bool, ...)`; this function only reads the first bool word.
     function preLaunch(
         string memory name_,
         string memory ticker_,
@@ -176,8 +198,10 @@ contract BondingV5 is
         bool needAcf_,
         uint8 antiSniperTaxType_,
         bool isProject60days_,
-        bool isFeeDelegation_
+        bytes calldata extParams_
     ) public nonReentrant returns (address, address, uint, uint256) {
+        bool isFeeDelegation_ = _decodeIsFeeDelegation(extParams_);
+
         // Fail-fast: validate reserve bips and calculate bonding curve supply upfront
         // This validates: airdropBips <= maxAirdropBips AND totalReserved < maxTotalReservedBips
         uint256 bondingCurveSupplyBase = bondingConfig

--- a/contracts/launchpadv2/BondingV5.sol
+++ b/contracts/launchpadv2/BondingV5.sol
@@ -109,6 +109,8 @@ contract BondingV5 is
     // Mapping to store graduation threshold for each token (calculated per-token based on airdropBips and needAcf)
     mapping(address => uint256) public tokenGradThreshold;
 
+    mapping(address => bool) public isFeeDelegation;
+
     event PreLaunched(
         address indexed token,
         address indexed pair,
@@ -173,7 +175,8 @@ contract BondingV5 is
         uint16 airdropBips_,
         bool needAcf_,
         uint8 antiSniperTaxType_,
-        bool isProject60days_
+        bool isProject60days_,
+        bool isFeeDelegation_
     ) public nonReentrant returns (address, address, uint, uint256) {
         // Fail-fast: validate reserve bips and calculate bonding curve supply upfront
         // This validates: airdropBips <= maxAirdropBips AND totalReserved < maxTotalReservedBips
@@ -350,6 +353,7 @@ contract BondingV5 is
             antiSniperTaxType: antiSniperTaxType_,
             isProject60days: isProject60days_
         });
+        isFeeDelegation[token] = isFeeDelegation_;
 
         // Set Data struct fields
         newToken.data.token = token;
@@ -448,7 +452,7 @@ contract BondingV5 is
 
         // X_LAUNCH, ACP_SKILL, and Project60days: taxRecipient (AgentTax) must be updated by the backend
         // before trading starts; only privileged backend wallets may call launch() so that ordering is enforced.
-        if (isProject60days(tokenAddress_) || isProjectXLaunch(tokenAddress_) || isAcpSkillLaunch(tokenAddress_)) {
+        if (isFeeDelegation[tokenAddress_] || isProject60days(tokenAddress_) || isProjectXLaunch(tokenAddress_) || isAcpSkillLaunch(tokenAddress_)) {
             if (!bondingConfig.isPrivilegedLauncher(msg.sender)) {
                 revert UnauthorizedLauncher();
             }

--- a/contracts/launchpadv2/MockPositionDescriptor.sol
+++ b/contracts/launchpadv2/MockPositionDescriptor.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+/// @dev Minimal stand-in (matches Uniswap `INonfungiblePositionManager` in ABI as `address`).
+interface INonfungiblePositionManager {}
+
+/// @dev Same `tokenURI` selector as `@uniswap/v3-periphery` `INonfungibleTokenPositionDescriptor`.
+interface INonfungibleTokenPositionDescriptor {
+    function tokenURI(INonfungiblePositionManager positionManager, uint256 tokenId)
+        external
+        view
+        returns (string memory);
+}
+
+/// @notice Minimal NFT position descriptor for testnet (e.g. deployUniswapV3TestnetLiquidity).
+contract MockPositionDescriptor is INonfungibleTokenPositionDescriptor {
+    function tokenURI(INonfungiblePositionManager, uint256)
+        external
+        pure
+        override
+        returns (string memory)
+    {
+        return "";
+    }
+}

--- a/contracts/tax/AgentTaxV2.sol
+++ b/contracts/tax/AgentTaxV2.sol
@@ -14,6 +14,7 @@ interface IBondingV5ForTaxV2 {
     function isProject60days(address token) external view returns (bool);
     function isProjectXLaunch(address token) external view returns (bool);
     function isAcpSkillLaunch(address token) external view returns (bool);
+    function isFeeDelegation(address token) external view returns (bool);
 }
 
 /**
@@ -248,7 +249,8 @@ contract AgentTaxV2 is Initializable, AccessControlUpgradeable {
 
         bool isSpecialLaunch = bondingV5.isProject60days(tokenAddress) ||
             bondingV5.isProjectXLaunch(tokenAddress) ||
-            bondingV5.isAcpSkillLaunch(tokenAddress);
+            bondingV5.isAcpSkillLaunch(tokenAddress) ||
+            bondingV5.isFeeDelegation(tokenAddress);
 
         require(isSpecialLaunch, "Token is not a special launch type");
 

--- a/scripts/launchpadv5/deployUniswapV3TestnetLiquidity.ts
+++ b/scripts/launchpadv5/deployUniswapV3TestnetLiquidity.ts
@@ -1,6 +1,10 @@
 /**
- * Deploy minimal Uniswap V3 stack (Factory + WETH9 + SwapRouter + NFT descriptor + PositionManager),
+ * Deploy minimal Uniswap V3 stack (Factory + WETH9 + SwapRouter + QuoterV2 + NFT descriptor + PositionManager),
  * create a VIRTUAL/stable pool, add liquidity, and run buy/sell smoke swaps.
+ *
+ * QuoterV2 vs factory/router:
+ * - Same constructor immutables as SwapRouter: `(UniswapV3Factory, WETH9)`. It does not use the router.
+ * - It quotes by staticcalling `pool.swap` and decoding the synthetic revert payload; pools must match this factory.
  *
  * Usage:
  *   # local hardhat network
@@ -9,24 +13,33 @@
  *   # bsc testnet
  *   ENV_FILE=.env.launchpadv5_dev_bsc_testnet npx hardhat run ./scripts/launchpadv5/deployUniswapV3TestnetLiquidity.ts --network bsc_testnet
  *
- * Required env (for testnet):
+ * Required env:
  *   VIRTUAL_TOKEN_ADDRESS
+ *   AGENT_TAX_ASSET_TOKEN
+ *
+ * Optional env — reuse existing deployments (same pattern as deployLaunchpadv5_0: set address to skip deploy):
+ *   UNISWAP_V3_FACTORY
+ *   UNISWAP_V3_WETH9
+ *   UNISWAP_V3_POSITION_DESCRIPTOR (MockPositionDescriptor)
+ *   UNISWAP_V3_ROUTER
+ *   UNISWAP_V3_QUOTER_V2
+ *   UNISWAP_V3_POSITION_MANAGER
  *
  * Optional env:
- *   AGENT_TAX_ASSET_TOKEN          (existing stable token; if empty script deploys MockERC20Decimals)
  *   LIQUIDITY_AMOUNT               (default "10")
  *   SWAP_TEST_VIRTUAL_AMOUNT       (default "1")
- *   V3_FEE                         (default "3000")
+ *   UNISWAP_V3_FEE                 (default "3000")
  *   TX_CONFIRM_TIMEOUT_MS          (default "240000")
- *   VERIFY_CONTRACTS=true          (auto verify on explorer when possible)
+ *   VERIFY_CONTRACTS=true          (verify after each newly deployed contract)
  *
  * Monad: fees scale with gas_limit (not gas_used). Script uses {@link launchpadHeavyTxGasLimit}.
  * Large deploys may take minutes to confirm — progress is logged before each step.
  */
-import { parseUnits } from "ethers";
+import { Contract, parseUnits } from "ethers";
 import { launchpadHeavyTxGasLimit } from "./utils";
 import FactoryArtifact from "@uniswap/v3-core/artifacts/contracts/UniswapV3Factory.sol/UniswapV3Factory.json";
 import SwapRouterArtifact from "@uniswap/v3-periphery/artifacts/contracts/SwapRouter.sol/SwapRouter.json";
+import QuoterV2Artifact from "@uniswap/v3-periphery/artifacts/contracts/lens/QuoterV2.sol/QuoterV2.json";
 import PositionManagerArtifact from "@uniswap/v3-periphery/artifacts/contracts/NonfungiblePositionManager.sol/NonfungiblePositionManager.json";
 import WethArtifact from "@uniswap/v2-periphery/build/WETH9.json";
 
@@ -53,6 +66,11 @@ const POOL_ABI = [
 const Q96 = 2n ** 96n;
 
 /** Capped via {@link launchpadHeavyTxGasLimit} (env: LAUNCHPAD_HEAVY_TX_GAS_LIMIT). */
+
+/** Single env var name (shared names like `VIRTUAL_TOKEN_ADDRESS` stay as-is). */
+function envStr(name: string): string {
+  return (process.env[name] || "").trim();
+}
 
 function mustAddress(name: string, value?: string): string {
   const v = String(value || "").trim();
@@ -98,7 +116,7 @@ async function tryVerify(address: string, ctorArgs: any[]) {
     const deployerAddress = await deployer.getAddress();
     const chainId = (await ethers.provider.getNetwork()).chainId;
     const timeoutMs = Number(process.env.TX_CONFIRM_TIMEOUT_MS || "240000");
-    const fee = Number(process.env.V3_FEE || "3000");
+    const fee = Number(envStr("UNISWAP_V3_FEE") || "3000");
     const liquidityHuman = process.env.LIQUIDITY_AMOUNT?.trim() || "10";
     const swapVirtualHuman = process.env.SWAP_TEST_VIRTUAL_AMOUNT?.trim() || "1";
 
@@ -111,48 +129,16 @@ async function tryVerify(address: string, ctorArgs: any[]) {
       "(If this line is the last for several minutes: RPC is slow, or a deploy tx is pending — check explorer / RPC.)"
     );
 
-    let virtualAddr = (process.env.VIRTUAL_TOKEN_ADDRESS || "").trim();
-    const hardhatNeedsMockVirtual =
-      hre.network.name === "hardhat" &&
-      (!ethers.isAddress(virtualAddr) ||
-        (await ethers.provider.getCode(virtualAddr)) === "0x");
-    if (hardhatNeedsMockVirtual) {
-      console.log("VIRTUAL_TOKEN_ADDRESS missing on hardhat, deploying mock VIRTUAL...");
-      const Mock = await ethers.getContractFactory("MockERC20Decimals");
-      const m = await Mock.deploy(
-        "Mock VIRTUAL",
-        "mVIRTUAL",
-        18,
-        deployerAddress,
-        parseUnits("1000000", 18),
-        { gasLimit: MAX_SIGNER_GAS_LIMIT }
-      );
-      await m.waitForDeployment();
-      virtualAddr = await m.getAddress();
+    const virtualRaw = envStr("VIRTUAL_TOKEN_ADDRESS");
+    if (!virtualRaw) {
+      throw new Error("VIRTUAL_TOKEN_ADDRESS not set in environment");
     }
-    virtualAddr = mustAddress("VIRTUAL_TOKEN_ADDRESS", virtualAddr);
-
-    let stableAddr = (process.env.AGENT_TAX_ASSET_TOKEN || "").trim();
-    const hardhatNeedsMockStable =
-      hre.network.name === "hardhat" &&
-      (!ethers.isAddress(stableAddr) ||
-        (ethers.isAddress(stableAddr) &&
-          (await ethers.provider.getCode(stableAddr)) === "0x"));
-    if (!ethers.isAddress(stableAddr) || hardhatNeedsMockStable) {
-      console.log("AGENT_TAX_ASSET_TOKEN missing, deploying mock stable (6 decimals)...");
-      const Mock = await ethers.getContractFactory("MockERC20Decimals");
-      const s = await Mock.deploy(
-        "Mock USDC",
-        "mUSDC",
-        6,
-        deployerAddress,
-        parseUnits("1000000", 6),
-        { gasLimit: MAX_SIGNER_GAS_LIMIT }
-      );
-      await s.waitForDeployment();
-      stableAddr = await s.getAddress();
+    const stableRaw = envStr("AGENT_TAX_ASSET_TOKEN");
+    if (!stableRaw) {
+      throw new Error("AGENT_TAX_ASSET_TOKEN not set in environment");
     }
-    stableAddr = mustAddress("AGENT_TAX_ASSET_TOKEN", stableAddr);
+    const virtualAddr = mustAddress("VIRTUAL_TOKEN_ADDRESS", virtualRaw);
+    const stableAddr = mustAddress("AGENT_TAX_ASSET_TOKEN", stableRaw);
 
     const virtual = new ethers.Contract(virtualAddr, ERC20_ABI, deployer);
     const stable = new ethers.Contract(stableAddr, ERC20_ABI, deployer);
@@ -166,67 +152,141 @@ async function tryVerify(address: string, ctorArgs: any[]) {
     const amountStable = parseUnits(liquidityHuman, stableDecimals);
     const amountSwapIn = parseUnits(swapVirtualHuman, virtualDecimals);
 
-    // Deploy v3 core/periphery minimal set
+    // ============================================
+    // Uniswap V3 stack (deployLaunchpadv5_0 style: env set → reuse, else deploy)
+    // ============================================
     const Factory = new ethers.ContractFactory(FactoryArtifact.abi, FactoryArtifact.bytecode, deployer);
-    console.log("\n1/5 Deploying UniswapV3Factory...");
-    const factory = await Factory.deploy({ gasLimit: MAX_SIGNER_GAS_LIMIT });
-    console.log("  tx:", factory.deploymentTransaction()?.hash ?? "(unknown)");
-    await factory.waitForDeployment();
-    const factoryAddr = await factory.getAddress();
-    console.log("  confirmed:", factoryAddr);
+    let factoryAddr: string;
+    const uniswapV3FactoryEnv = envStr("UNISWAP_V3_FACTORY");
+    if (!uniswapV3FactoryEnv) {
+      console.log("\n--- Deploying UniswapV3Factory ---");
+      const factory = await Factory.deploy({ gasLimit: MAX_SIGNER_GAS_LIMIT });
+      console.log("  tx:", factory.deploymentTransaction()?.hash ?? "(unknown)");
+      await factory.waitForDeployment();
+      factoryAddr = await factory.getAddress();
+      console.log("  deployed:", factoryAddr);
+      await tryVerify(factoryAddr, []);
+    } else {
+      console.log("\n--- Reusing UNISWAP_V3_FACTORY ---");
+      factoryAddr = ethers.getAddress(uniswapV3FactoryEnv);
+      console.log(factoryAddr);
+    }
 
     const Weth = new ethers.ContractFactory(WethArtifact.abi, WethArtifact.bytecode, deployer);
-    console.log("2/5 Deploying WETH9...");
-    const weth = await Weth.deploy({ gasLimit: MAX_SIGNER_GAS_LIMIT });
-    console.log("  tx:", weth.deploymentTransaction()?.hash ?? "(unknown)");
-    await weth.waitForDeployment();
-    const wethAddr = await weth.getAddress();
-    console.log("  confirmed:", wethAddr);
+    let wethAddr: string;
+    const uniswapV3Weth9Env = envStr("UNISWAP_V3_WETH9");
+    if (!uniswapV3Weth9Env) {
+      console.log("\n--- Deploying WETH9 ---");
+      const weth = await Weth.deploy({ gasLimit: MAX_SIGNER_GAS_LIMIT });
+      console.log("  tx:", weth.deploymentTransaction()?.hash ?? "(unknown)");
+      await weth.waitForDeployment();
+      wethAddr = await weth.getAddress();
+      console.log("  deployed:", wethAddr);
+      await tryVerify(wethAddr, []);
+    } else {
+      console.log("\n--- Reusing UNISWAP_V3_WETH9 ---");
+      wethAddr = ethers.getAddress(uniswapV3Weth9Env);
+      console.log(wethAddr);
+    }
 
     const Descriptor = await ethers.getContractFactory("MockPositionDescriptor");
-    console.log("3/5 Deploying MockPositionDescriptor...");
-    const descriptor = await Descriptor.deploy({ gasLimit: MAX_SIGNER_GAS_LIMIT });
-    console.log("  tx:", descriptor.deploymentTransaction()?.hash ?? "(unknown)");
-    await descriptor.waitForDeployment();
-    const descriptorAddr = await descriptor.getAddress();
-    console.log("  confirmed:", descriptorAddr);
+    let descriptorAddr: string;
+    const uniswapV3DescriptorEnv = envStr("UNISWAP_V3_POSITION_DESCRIPTOR");
+    if (!uniswapV3DescriptorEnv) {
+      console.log("\n--- Deploying MockPositionDescriptor ---");
+      const descriptor = await Descriptor.deploy({ gasLimit: MAX_SIGNER_GAS_LIMIT });
+      console.log("  tx:", descriptor.deploymentTransaction()?.hash ?? "(unknown)");
+      await descriptor.waitForDeployment();
+      descriptorAddr = await descriptor.getAddress();
+      console.log("  deployed:", descriptorAddr);
+      await tryVerify(descriptorAddr, []);
+    } else {
+      console.log("\n--- Reusing UNISWAP_V3_POSITION_DESCRIPTOR ---");
+      descriptorAddr = ethers.getAddress(uniswapV3DescriptorEnv);
+      console.log(descriptorAddr);
+    }
 
     const Router = new ethers.ContractFactory(SwapRouterArtifact.abi, SwapRouterArtifact.bytecode, deployer);
-    console.log("4/5 Deploying SwapRouter...");
-    const router = await Router.deploy(factoryAddr, wethAddr, { gasLimit: MAX_SIGNER_GAS_LIMIT });
-    console.log("  tx:", router.deploymentTransaction()?.hash ?? "(unknown)");
-    await router.waitForDeployment();
-    const routerAddr = await router.getAddress();
-    console.log("  confirmed:", routerAddr);
+    let routerAddr: string;
+    const uniswapV3RouterEnv = envStr("UNISWAP_V3_ROUTER");
+    if (!uniswapV3RouterEnv) {
+      console.log("\n--- Deploying SwapRouter ---");
+      const routerDeployed = await Router.deploy(factoryAddr, wethAddr, { gasLimit: MAX_SIGNER_GAS_LIMIT });
+      console.log("  tx:", routerDeployed.deploymentTransaction()?.hash ?? "(unknown)");
+      await routerDeployed.waitForDeployment();
+      routerAddr = await routerDeployed.getAddress();
+      console.log("  deployed:", routerAddr);
+      await tryVerify(routerAddr, [factoryAddr, wethAddr]);
+    } else {
+      console.log("\n--- Reusing UNISWAP_V3_ROUTER ---");
+      routerAddr = ethers.getAddress(uniswapV3RouterEnv);
+      console.log(routerAddr);
+    }
+
+    const QuoterV2 = new ethers.ContractFactory(QuoterV2Artifact.abi, QuoterV2Artifact.bytecode, deployer);
+    let quoterV2Addr: string;
+    const uniswapV3QuoterEnv = envStr("UNISWAP_V3_QUOTER_V2");
+    if (!uniswapV3QuoterEnv) {
+      console.log("\n--- Deploying QuoterV2 ---");
+      const quoterV2 = await QuoterV2.deploy(factoryAddr, wethAddr, { gasLimit: MAX_SIGNER_GAS_LIMIT });
+      console.log("  tx:", quoterV2.deploymentTransaction()?.hash ?? "(unknown)");
+      await quoterV2.waitForDeployment();
+      quoterV2Addr = await quoterV2.getAddress();
+      console.log("  deployed:", quoterV2Addr);
+      await tryVerify(quoterV2Addr, [factoryAddr, wethAddr]);
+    } else {
+      console.log("\n--- Reusing UNISWAP_V3_QUOTER_V2 ---");
+      quoterV2Addr = ethers.getAddress(uniswapV3QuoterEnv);
+      console.log(quoterV2Addr);
+    }
 
     const PositionManager = new ethers.ContractFactory(
       PositionManagerArtifact.abi,
       PositionManagerArtifact.bytecode,
       deployer
     );
-    console.log("5/5 Deploying NonfungiblePositionManager (largest bytecode)...");
-    const positionManager = await PositionManager.deploy(factoryAddr, wethAddr, descriptorAddr, {
-      gasLimit: MAX_SIGNER_GAS_LIMIT,
-    });
-    console.log("  tx:", positionManager.deploymentTransaction()?.hash ?? "(unknown)");
-    await positionManager.waitForDeployment();
-    const positionManagerAddr = await positionManager.getAddress();
-    console.log("  confirmed:", positionManagerAddr);
+    let positionManagerAddr: string;
+    let positionManager: Contract;
+    const uniswapV3PmEnv = envStr("UNISWAP_V3_POSITION_MANAGER");
+    if (!uniswapV3PmEnv) {
+      console.log("\n--- Deploying NonfungiblePositionManager ---");
+      const pm = await PositionManager.deploy(factoryAddr, wethAddr, descriptorAddr, {
+        gasLimit: MAX_SIGNER_GAS_LIMIT,
+      });
+      console.log("  tx:", pm.deploymentTransaction()?.hash ?? "(unknown)");
+      await pm.waitForDeployment();
+      positionManagerAddr = await pm.getAddress();
+      console.log("  deployed:", positionManagerAddr);
+      positionManager = pm;
+      await tryVerify(positionManagerAddr, [factoryAddr, wethAddr, descriptorAddr]);
+    } else {
+      console.log("\n--- Reusing UNISWAP_V3_POSITION_MANAGER ---");
+      positionManagerAddr = ethers.getAddress(uniswapV3PmEnv);
+      console.log(positionManagerAddr);
+      positionManager = new Contract(positionManagerAddr, PositionManagerArtifact.abi, deployer);
+    }
+
+    const router = new Contract(routerAddr, SwapRouterArtifact.abi, deployer);
 
     console.log("UniswapV3Factory:", factoryAddr);
     console.log("WETH9:", wethAddr);
     console.log("SwapRouter:", routerAddr);
+    console.log("QuoterV2:", quoterV2Addr);
     console.log("PositionDescriptor:", descriptorAddr);
     console.log("PositionManager:", positionManagerAddr);
 
     // Create and initialize pool (1:1)
     const factoryRW = new ethers.Contract(factoryAddr, V3_FACTORY_ABI, deployer);
+    let createPoolTxHash: string | undefined;
+    let initializePoolTxHash: string | undefined;
     let poolAddr = await factoryRW.getPool(virtualAddr, stableAddr, fee);
     if (poolAddr === ethers.ZeroAddress) {
+      console.log("\n--- Factory.createPool ---");
       const txCreate = await factoryRW.createPool(virtualAddr, stableAddr, fee, {
         gasLimit: MAX_SIGNER_GAS_LIMIT,
       });
       const r = await waitTx(txCreate.hash, timeoutMs);
+      createPoolTxHash = r.hash;
       console.log("createPool tx:", r.hash);
       poolAddr = await factoryRW.getPool(virtualAddr, stableAddr, fee);
     }
@@ -234,18 +294,25 @@ async function tryVerify(address: string, ctorArgs: any[]) {
     const pool = new ethers.Contract(poolAddr, POOL_ABI, deployer);
     const slot0 = await pool.slot0().catch(() => null);
     if (!slot0 || slot0[0] === 0n) {
+      console.log("\n--- Pool.initialize ---");
       const txInit = await pool.initialize(Q96, { gasLimit: MAX_SIGNER_GAS_LIMIT });
       const r = await waitTx(txInit.hash, timeoutMs);
+      initializePoolTxHash = r.hash;
       console.log("initialize pool tx:", r.hash);
     }
 
     // Approve + mint liquidity position
+    console.log("\n--- Approving NonfungiblePositionManager ---");
     const needVirtual = amountVirtual + amountSwapIn;
     if ((await virtual.allowance(deployerAddress, positionManagerAddr)) < needVirtual) {
       await (await virtual.approve(positionManagerAddr, needVirtual)).wait();
+      console.log(
+        `Approved VIRTUAL for PositionManager (${needVirtual} base units = liquidity + swap test)`
+      );
     }
     if ((await stable.allowance(deployerAddress, positionManagerAddr)) < amountStable) {
       await (await stable.approve(positionManagerAddr, amountStable)).wait();
+      console.log("Approved stable for PositionManager");
     }
 
     const token0 = virtualAddr.toLowerCase() < stableAddr.toLowerCase() ? virtualAddr : stableAddr;
@@ -268,13 +335,19 @@ async function tryVerify(address: string, ctorArgs: any[]) {
       recipient: deployerAddress,
       deadline: deadlineSec(),
     };
+    console.log("\n--- NonfungiblePositionManager.mint ---");
+    console.log(
+      `VIRTUAL: ${amountVirtual} base units (${liquidityHuman} * 10^${virtualDecimals}) | stable: ${amountStable} base units (${liquidityHuman} * 10^${stableDecimals}) | ticks [${tickLower}, ${tickUpper}] fee ${fee}`
+    );
     const txMint = await positionManager.mint(mintParams, { gasLimit: MAX_SIGNER_GAS_LIMIT });
     const rcMint = await waitTx(txMint.hash, timeoutMs);
-    console.log("mint liquidity tx:", rcMint.hash);
+    console.log("mint tx:", rcMint.hash);
 
     // Swap smoke: virtual -> stable (buy) then stable -> virtual (sell)
+    console.log("\n--- Approving SwapRouter (swap smoke) ---");
     if ((await virtual.allowance(deployerAddress, routerAddr)) < amountSwapIn) {
       await (await virtual.approve(routerAddr, amountSwapIn)).wait();
+      console.log(`Approved VIRTUAL for Router (${amountSwapIn} base units for swap test)`);
     }
     const buyParams = {
       tokenIn: virtualAddr,
@@ -286,14 +359,19 @@ async function tryVerify(address: string, ctorArgs: any[]) {
       amountOutMinimum: 0n,
       sqrtPriceLimitX96: 0n,
     };
+    console.log("\n--- router.exactInputSingle (VIRTUAL → stable) ---");
+    console.log(
+      `Swapping ${swapVirtualHuman} VIRTUAL (${amountSwapIn} base units) → stable, amountOutMinimum=0 (dev only)`
+    );
     const txBuy = await router.exactInputSingle(buyParams, { gasLimit: MAX_SIGNER_GAS_LIMIT });
     const rcBuy = await waitTx(txBuy.hash, timeoutMs);
-    console.log("buy swap tx:", rcBuy.hash);
+    console.log("exactInputSingle buy tx:", rcBuy.hash);
 
     const stableBal = await stable.balanceOf(deployerAddress);
     if (stableBal <= 0n) throw new Error("buy smoke failed: zero stable received");
     if ((await stable.allowance(deployerAddress, routerAddr)) < stableBal) {
       await (await stable.approve(routerAddr, stableBal)).wait();
+      console.log("Approved stable for Router (full balance for sell-back smoke)");
     }
     const sellParams = {
       tokenIn: stableAddr,
@@ -305,26 +383,37 @@ async function tryVerify(address: string, ctorArgs: any[]) {
       amountOutMinimum: 0n,
       sqrtPriceLimitX96: 0n,
     };
+    console.log("\n--- router.exactInputSingle (stable → VIRTUAL) ---");
+    console.log(
+      `Swapping full stable balance (${stableBal} base units) → VIRTUAL, amountOutMinimum=0 (dev only)`
+    );
     const txSell = await router.exactInputSingle(sellParams, { gasLimit: MAX_SIGNER_GAS_LIMIT });
     const rcSell = await waitTx(txSell.hash, timeoutMs);
-    console.log("sell swap tx:", rcSell.hash);
+    console.log("exactInputSingle sell tx:", rcSell.hash);
 
     console.log("\n✅ Uniswap V3 deploy + liquidity + buy/sell smoke passed");
 
-    // Optional verify
-    await tryVerify(factoryAddr, []);
-    await tryVerify(wethAddr, []);
-    await tryVerify(descriptorAddr, []);
-    await tryVerify(routerAddr, [factoryAddr, wethAddr]);
-    await tryVerify(positionManagerAddr, [factoryAddr, wethAddr, descriptorAddr]);
-
     console.log("\n--- Paste into env if needed ---");
     console.log(`UNISWAP_V3_FACTORY=${factoryAddr}`);
+    console.log(`UNISWAP_V3_WETH9=${wethAddr}`);
+    console.log(`UNISWAP_V3_POSITION_DESCRIPTOR=${descriptorAddr}`);
     console.log(`UNISWAP_V3_ROUTER=${routerAddr}`);
+    console.log(`UNISWAP_V3_QUOTER_V2=${quoterV2Addr}`);
     console.log(`UNISWAP_V3_POSITION_MANAGER=${positionManagerAddr}`);
     console.log(`UNISWAP_V3_POOL=${poolAddr}`);
-    console.log(`AGENT_TAX_ASSET_TOKEN=${stableAddr}`);
     console.log(`VIRTUAL_TOKEN_ADDRESS=${virtualAddr}`);
+    console.log(`AGENT_TAX_ASSET_TOKEN=${stableAddr}`);
+    console.log("");
+    console.log(
+      `# createPool tx: ${createPoolTxHash ?? "(skipped — pool already existed)"}`
+    );
+    console.log(`# Pool: ${poolAddr}`);
+    console.log(
+      `# initialize pool tx: ${initializePoolTxHash ?? "(skipped — already initialized)"}`
+    );
+    console.log(`# mint liquidity tx: ${rcMint.hash}`);
+    console.log(`# buy swap tx: ${rcBuy.hash}`);
+    console.log(`# sell swap tx: ${rcSell.hash}`);
   } catch (e: any) {
     console.error(e);
     process.exit(1);

--- a/scripts/launchpadv5/e2e_test.ts
+++ b/scripts/launchpadv5/e2e_test.ts
@@ -20,6 +20,8 @@ import {
   ANTI_SNIPER_60S,
   ANTI_SNIPER_98M,
   launchModeLabel,
+  PRELAUNCH_EXT_PARAMS_FEE_DELEGATION_TRUE,
+  extParamsImpliesFeeDelegation,
 } from "./launchpadv5Common";
 import { launchpadDefaultTxGasLimit } from "./utils";
 const { ethers } = require("hardhat");
@@ -227,6 +229,9 @@ async function main() {
   const antiSniperTaxType = ANTI_SNIPER_60S; // 60 seconds anti-sniper
   const isProject60days = false;
 
+  /** BondingV5 extParams V1 — matches default in `executePreLaunch` (fee delegation / `isFeeDelegation`). */
+  const preLaunchExtParams = PRELAUNCH_EXT_PARAMS_FEE_DELEGATION_TRUE;
+
   const isScheduledLaunchPreview =
     startTime >= currentTimestamp + startTimeDelayNum;
 
@@ -244,18 +249,24 @@ async function main() {
   console.log("Need ACF:", needAcf);
   console.log("Anti-Sniper Tax Type:", antiSniperTaxType, "(60S)");
   console.log("Is Project 60 Days:", isProject60days);
+  console.log(
+    "preLaunch extParams (fee delegation → isFeeDelegation):",
+    preLaunchExtParams,
+    "(expects true on-chain)"
+  );
 
-  // For X_LAUNCH / ACP_SKILL and Project60days launches, BondingV5 requires privileged backend wallet.
+  // X_LAUNCH / ACP_SKILL / Project60days / fee-delegation tokens: BondingV5.launch requires privileged launcher.
   if (
     launchMode === LAUNCH_MODE_X_LAUNCH ||
     launchMode === LAUNCH_MODE_ACP_SKILL ||
-    isProject60days
+    isProject60days ||
+    extParamsImpliesFeeDelegation(preLaunchExtParams)
   ) {
     const isPrivilegedLauncher = await bondingConfig.isPrivilegedLauncher(await signer.getAddress());
     console.log("Signer isPrivilegedLauncher:", isPrivilegedLauncher);
     if (!isPrivilegedLauncher) {
       throw new Error(
-        `Signer ${await signer.getAddress()} is not a privileged launcher for ${launchModeLabel(launchMode)} preLaunch/launch flow`
+        `Signer ${await signer.getAddress()} is not a privileged launcher for ${launchModeLabel(launchMode)} / fee-delegation launch flow`
       );
     }
   }
@@ -295,6 +306,7 @@ async function main() {
     needAcf,
     antiSniperTaxType,
     isProject60days,
+    extParams: preLaunchExtParams,
     runDiagnostics: true,
   });
 
@@ -355,6 +367,15 @@ async function main() {
   console.log("isProject60days():", isProject60daysResult, "(expected:", isProject60days, ")");
   console.log("tokenAntiSniperType():", tokenAntiSniperTypeResult, "(expected:", antiSniperTaxType, ")");
   console.log("tokenGradThreshold():", formatEther(tokenGradThreshold), "tokens");
+
+  const isFeeDelegationOnChain = await bondingV5.isFeeDelegation(tokenAddress);
+  console.log(
+    "isFeeDelegation():",
+    isFeeDelegationOnChain,
+    "(expected:",
+    extParamsImpliesFeeDelegation(preLaunchExtParams),
+    ")"
+  );
 
   // Verify anti-sniper duration from BondingConfig
   const antiSniperDuration = await bondingConfig.getAntiSniperDuration(antiSniperTaxType);

--- a/scripts/launchpadv5/handle_univ2_buy_sell.ts
+++ b/scripts/launchpadv5/handle_univ2_buy_sell.ts
@@ -49,8 +49,8 @@ const { ethers } = require("hardhat");
 // Edit only this (agent ERC20)
 // ============================================
 // const AGENT_TOKEN_ADDRESS = "0x17742fa86139ed9dB81B2ec8037b2525061F97B9" as string;
-const AGENT_TOKEN_ADDRESS = "0xcBFF2B7Bf9A85e9019955a060024f4d3269BECb6" as string;
-const buyHuman = process.env.BUY_VIRTUAL_AMOUNT?.trim() || "99";
+const AGENT_TOKEN_ADDRESS = "0x1cD8eD80aA4479920D8C74b62677b161F7eC2F46" as string;
+const buyHuman = process.env.BUY_VIRTUAL_AMOUNT?.trim() || "9900";
 
 const ERC20_ABI = [
   "function approve(address spender, uint256 amount) external returns (bool)",
@@ -100,6 +100,17 @@ async function main() {
   }
 
   const virtualAddr = process.env.VIRTUAL_TOKEN_ADDRESS?.trim();
+  /*
+  If we encounter error below, it means the agentToken.router is not the same as the factory.
+  Because we are swticthing the base-sepolia uniswapV2Router to our own deployed one.
+
+  Previous one: UNISWAP_V2_ROUTER=0x1689E7B1F10000AE47eBfE339a4f69dECd19F602 # 
+  New one: UNISWAP_V2_ROUTER=0x3AE8ce55b48Ac924F96C48E987439Ade017A2c2F # mocked Uniswap V2 Router
+
+  Example error:
+  factory.getPair(VIRTUAL, agent): 0x0000000000000000000000000000000000000000
+⚠️ No pair on this factory for VIRTUAL/agent — swaps will likely revert (wrong router or not graduated).
+  */
   const routerAddr = process.env.UNISWAP_V2_ROUTER?.trim();
   if (!virtualAddr) throw new Error("VIRTUAL_TOKEN_ADDRESS is required");
   if (!routerAddr) throw new Error("UNISWAP_V2_ROUTER is required");

--- a/scripts/launchpadv5/launchpadv5Common.ts
+++ b/scripts/launchpadv5/launchpadv5Common.ts
@@ -1,7 +1,7 @@
 /**
  * Shared BondingV5 launch + Project60days graduation helpers for scripts (e2e, drain tests).
  */
-import { formatEther, parseEther } from "ethers";
+import { AbiCoder, formatEther, parseEther } from "ethers";
 import type { Contract, Signer } from "ethers";
 import {
   launchpadDefaultTxGasLimit,
@@ -27,6 +27,26 @@ export const DEFAULT_SCHEDULED_START_OFFSET_SEC = 86400;
 
 /** Aligns with BondingConfig 60s anti-sniper window (ANTI_SNIPER_60S); override via ANTI_SNIPER_WAIT_SECONDS */
 export const DEFAULT_ANTI_SNIPER_WAIT_BEFORE_GRAD_SEC = 60 + 10;
+
+/**
+ * BondingV5 `preLaunch` extParams V1: first 32 bytes = `abi.encode(bool isFeeDelegation)` (app: fee delegation).
+ * Used as default for script helpers so `bondingV5.isFeeDelegation(token)` is true after preLaunch.
+ */
+export const PRELAUNCH_EXT_PARAMS_FEE_DELEGATION_TRUE =
+  AbiCoder.defaultAbiCoder().encode(["bool"], [true]) as `0x${string}`;
+
+/** Empty extParams ⇒ on-chain `isFeeDelegation` false (BondingV5 `_decodeIsFeeDelegation`). */
+export const PRELAUNCH_EXT_PARAMS_NONE = "0x" as const;
+
+/**
+ * Mirrors BondingV5 `_decodeIsFeeDelegation` — used to know if `launch()` requires `BondingConfig.isPrivilegedLauncher`.
+ */
+export function extParamsImpliesFeeDelegation(extParams: string): boolean {
+  const hex = extParams.startsWith("0x") ? extParams.slice(2) : extParams;
+  if (hex.length < 64) return false;
+  const word = BigInt("0x" + hex.slice(0, 64));
+  return word === 1n;
+}
 
 export function launchModeLabel(mode: number): string {
   if (mode === LAUNCH_MODE_NORMAL) return "NORMAL";
@@ -79,6 +99,11 @@ export interface ExecutePreLaunchParams {
   needAcf: boolean;
   antiSniperTaxType: number;
   isProject60days: boolean;
+  /**
+   * V1: first word `abi.encode(bool isFeeDelegation)`; empty `0x` ⇒ false.
+   * Default in `executePreLaunch` is fee-delegation true (`PRELAUNCH_EXT_PARAMS_FEE_DELEGATION_TRUE`).
+   */
+  extParams?: `0x${string}`;
   /** E2E-style staticCall + gas estimate logging */
   runDiagnostics?: boolean;
 }
@@ -121,6 +146,7 @@ export async function executePreLaunch(
     needAcf,
     antiSniperTaxType,
     isProject60days,
+    extParams = PRELAUNCH_EXT_PARAMS_FEE_DELEGATION_TRUE,
     runDiagnostics = true,
   } = params;
 
@@ -158,7 +184,8 @@ export async function executePreLaunch(
         airdropBips,
         needAcf,
         antiSniperTaxType,
-        isProject60days
+        isProject60days,
+        extParams
       );
       console.log(
         "✅ staticCall passed, proceeding with actual transaction..."
@@ -185,7 +212,8 @@ export async function executePreLaunch(
     airdropBips,
     needAcf,
     antiSniperTaxType,
-    isProject60days
+    isProject60days,
+    extParams
   );
   const cap = launchpadGasLimitCeilingBigint();
   const bps = preLaunchGasBufferBps();
@@ -214,6 +242,7 @@ export async function executePreLaunch(
     needAcf,
     antiSniperTaxType,
     isProject60days,
+    extParams,
     { gasLimit }
   );
 

--- a/scripts/launchpadv5/sweep_v3_project_tax.ts
+++ b/scripts/launchpadv5/sweep_v3_project_tax.ts
@@ -41,7 +41,7 @@ const SWEEP_V3_PROJECT_TAX_ROLE = ethers.keccak256(
 // ============================================
 // Agent token to sweep — hardcoded (change per regression / network)
 // ============================================
-const AGENT_TOKEN = "0xf11e998C52AB2860693337A31244E3C4312B449d";
+const AGENT_TOKEN = "0x1cD8eD80aA4479920D8C74b62677b161F7eC2F46";
 
 function assertSuccessfulReceipt(
   receipt: TransactionReceipt | null,

--- a/scripts/launchpadv5/verify_eip1167_clone_impl.ts
+++ b/scripts/launchpadv5/verify_eip1167_clone_impl.ts
@@ -115,7 +115,8 @@ async function main() {
   const expectedV3 = envAddr("AGENT_TOKEN_V3_IMPLEMENTATION") || "0x28DA9E5D949B0cc162796769bd03beD106f370B1";
   const expectedV4 = envAddr("AGENT_TOKEN_V4_IMPLEMENTATION") || "0xdfc000635776d152236b002D25F95fd34B3753a2";
 
-  const cloneV3 = "0x85A02c33aced66eD39a0fD07FB0cd8d75290939D";
+  // const cloneV3 = "0x85A02c33aced66eD39a0fD07FB0cd8d75290939D";
+  const cloneV3 = "0x1cD8eD80aA4479920D8C74b62677b161F7eC2F46";
   const cloneV4 = "0x17742fa86139ed9dB81B2ec8037b2525061F97B9";
 
   const factory = new hreEthers.Contract(factoryAddr, FACTORY_ABI, hreEthers.provider);

--- a/test/launchpadv5/bondingV5.js
+++ b/test/launchpadv5/bondingV5.js
@@ -166,7 +166,7 @@ describe("BondingV5", function () {
         false, // needAcf_
         ANTI_SNIPER_60S, // antiSniperTaxType_
         false // isProject60days_
-      );
+      ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -225,7 +225,7 @@ describe("BondingV5", function () {
             false,
             ANTI_SNIPER_60S,
             false
-          )
+          ,"0x")
       ).to.be.revertedWithCustomError(bondingV5, ERR_INVALID_INPUT);
     });
 
@@ -251,7 +251,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_60S,
           false
-        )
+        ,"0x")
       ).to.be.revertedWithCustomError(bondingV5, ERR_INVALID_INPUT);
     });
 
@@ -279,7 +279,7 @@ describe("BondingV5", function () {
         false,
         ANTI_SNIPER_60S,
         true // isProject60days_ = true
-      );
+      ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -331,7 +331,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_60S,
           false
-        );
+        ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -410,7 +410,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_60S,
           false
-        );
+        ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -485,7 +485,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_60S,
           false
-        );
+        ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -581,7 +581,7 @@ describe("BondingV5", function () {
         false, // needAcf must be false for special modes
         ANTI_SNIPER_60S, // antiSniperTaxType must be 60S for special modes
         false // isProject60days must be false for special modes
-      );
+      ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -639,7 +639,7 @@ describe("BondingV5", function () {
             false,
             ANTI_SNIPER_NONE,
             false
-          )
+          ,"0x")
       ).to.be.revertedWithCustomError(bondingV5, "UnauthorizedLauncher");
     });
 
@@ -670,7 +670,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_NONE,
           false
-        )
+        ,"0x")
       ).to.be.revertedWithCustomError(bondingV5, "InvalidSpecialLaunchParams");
     });
   });
@@ -719,7 +719,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_60S, // antiSniperTaxType must be 60S for special modes
           false
-        );
+        ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -779,7 +779,7 @@ describe("BondingV5", function () {
             false,
             ANTI_SNIPER_NONE,
             false
-          )
+          ,"0x")
       ).to.be.revertedWithCustomError(bondingV5, "UnauthorizedLauncher");
     });
   });
@@ -947,7 +947,7 @@ describe("BondingV5", function () {
           false,
           5, // Invalid anti-sniper type
           false
-        )
+        ,"0x")
       ).to.be.revertedWithCustomError(bondingV5, "InvalidAntiSniperType");
     });
   });
@@ -983,7 +983,7 @@ describe("BondingV5", function () {
             false,
             ANTI_SNIPER_60S,
             false
-          );
+          ,"0x");
 
         const receipt = await tx.wait();
         const event = receipt.logs.find((log) => {
@@ -1023,7 +1023,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_60S,
           false // MAX_AIRDROP_BIPS = 500 (5.00%)
-        );
+        ,"0x");
 
         const receipt = await tx.wait();
         const event = receipt.logs.find((log) => {
@@ -1063,7 +1063,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_60S,
           false // 300 = 3.00%
-        );
+        ,"0x");
 
         const receipt = await tx.wait();
         const event = receipt.logs.find((log) => {
@@ -1105,7 +1105,7 @@ describe("BondingV5", function () {
             false,
             ANTI_SNIPER_60S,
             false // 600 (6.00%) > MAX_AIRDROP_BIPS (500 = 5.00%)
-          )
+          ,"0x")
         ).to.be.revertedWithCustomError(bondingConfig, "AirdropBipsExceedsMax");
       });
     });
@@ -1138,7 +1138,7 @@ describe("BondingV5", function () {
           true,
           ANTI_SNIPER_60S,
           false // needAcf = true
-        );
+        ,"0x");
 
         const receipt = await tx.wait();
         const event = receipt.logs.find((log) => {
@@ -1185,7 +1185,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_60S,
           false // needAcf = false
-        );
+        ,"0x");
 
         const receipt = await tx.wait();
         const event = receipt.logs.find((log) => {
@@ -1232,7 +1232,7 @@ describe("BondingV5", function () {
           true,
           ANTI_SNIPER_60S,
           false // 500 (5.00%) + 5000 (50%) = 5500 (55%)
-        );
+        ,"0x");
 
         const receipt = await tx.wait();
         expect(receipt).to.not.be.undefined;
@@ -1264,7 +1264,7 @@ describe("BondingV5", function () {
           true,
           ANTI_SNIPER_60S,
           false // 400 (4.00%) + 5000 (50%) = 5400 (54%)
-        );
+        ,"0x");
 
         const receipt = await tx.wait();
         const event = receipt.logs.find((log) => {
@@ -1305,7 +1305,7 @@ describe("BondingV5", function () {
             false,
             ANTI_SNIPER_NONE,
             false
-          );
+          ,"0x");
 
         const receipt = await tx.wait();
         const event = receipt.logs.find((log) => {
@@ -1348,7 +1348,7 @@ describe("BondingV5", function () {
             false,
             ANTI_SNIPER_60S,
             false
-          );
+          ,"0x");
 
         const receipt = await tx.wait();
         const event = receipt.logs.find((log) => {
@@ -1391,7 +1391,7 @@ describe("BondingV5", function () {
             false,
             ANTI_SNIPER_98M,
             false
-          );
+          ,"0x");
 
         const receipt = await tx.wait();
         const event = receipt.logs.find((log) => {
@@ -1434,7 +1434,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_60S,
           true // isProject60days = true
-        );
+        ,"0x");
 
         const receipt = await tx.wait();
         const event = receipt.logs.find((log) => {
@@ -1473,7 +1473,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_60S,
           false // isProject60days = false
-        );
+        ,"0x");
 
         const receipt = await tx.wait();
         const event = receipt.logs.find((log) => {
@@ -1519,7 +1519,7 @@ describe("BondingV5", function () {
             false,
             ANTI_SNIPER_60S,
             false
-          );
+          ,"0x");
 
         const receipt = await tx.wait();
         expect(receipt).to.not.be.undefined;
@@ -1558,7 +1558,7 @@ describe("BondingV5", function () {
             false,
             ANTI_SNIPER_60S,
             false
-          );
+          ,"0x");
 
         const receipt = await tx.wait();
         expect(receipt).to.not.be.undefined;
@@ -1609,7 +1609,7 @@ describe("BondingV5", function () {
             false,
             ANTI_SNIPER_NONE,
             false
-          )
+          ,"0x")
       ).to.be.revertedWithCustomError(bondingV5, "InvalidSpecialLaunchParams");
     });
 
@@ -1641,7 +1641,7 @@ describe("BondingV5", function () {
             true,
             ANTI_SNIPER_NONE,
             false
-          )
+          ,"0x")
       ).to.be.revertedWithCustomError(bondingV5, "InvalidSpecialLaunchParams");
     });
 
@@ -1674,7 +1674,7 @@ describe("BondingV5", function () {
             false,
             ANTI_SNIPER_NONE, // Should revert: special modes require ANTI_SNIPER_60S
             false
-          )
+          ,"0x")
       ).to.be.revertedWithCustomError(bondingV5, "InvalidSpecialLaunchParams");
     });
 
@@ -1706,7 +1706,7 @@ describe("BondingV5", function () {
             false,
             ANTI_SNIPER_NONE,
             true
-          )
+          ,"0x")
       ).to.be.revertedWithCustomError(bondingV5, "InvalidSpecialLaunchParams");
     });
 
@@ -1739,7 +1739,7 @@ describe("BondingV5", function () {
             false,
             ANTI_SNIPER_NONE,
             false
-          )
+          ,"0x")
       ).to.be.revertedWithCustomError(bondingV5, "InvalidSpecialLaunchParams");
     });
 
@@ -1771,7 +1771,7 @@ describe("BondingV5", function () {
             false,
             ANTI_SNIPER_NONE,
             false
-          )
+          ,"0x")
       ).to.be.revertedWithCustomError(bondingV5, "InvalidSpecialLaunchParams");
     });
 
@@ -1803,7 +1803,7 @@ describe("BondingV5", function () {
             true,
             ANTI_SNIPER_NONE,
             false
-          )
+          ,"0x")
       ).to.be.revertedWithCustomError(bondingV5, "InvalidSpecialLaunchParams");
     });
 
@@ -1835,7 +1835,7 @@ describe("BondingV5", function () {
             false,
             ANTI_SNIPER_98M,
             false
-          )
+          ,"0x")
       ).to.be.revertedWithCustomError(bondingV5, "InvalidSpecialLaunchParams");
     });
 
@@ -1867,7 +1867,7 @@ describe("BondingV5", function () {
             false,
             ANTI_SNIPER_NONE,
             true
-          )
+          ,"0x")
       ).to.be.revertedWithCustomError(bondingV5, "InvalidSpecialLaunchParams");
     });
 
@@ -1900,7 +1900,7 @@ describe("BondingV5", function () {
             false,
             ANTI_SNIPER_NONE,
             false
-          )
+          ,"0x")
       ).to.be.revertedWithCustomError(bondingV5, "InvalidSpecialLaunchParams");
     });
   });
@@ -1933,7 +1933,7 @@ describe("BondingV5", function () {
         false,
         ANTI_SNIPER_98M,
         true // 500 = 5.00%
-      );
+      ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -1979,7 +1979,7 @@ describe("BondingV5", function () {
         false,
         ANTI_SNIPER_60S,
         false // 500 = 5.00%
-      );
+      ,"0x");
 
       let receipt = await tx.wait();
       let event = receipt.logs.find((log) => {
@@ -2047,7 +2047,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_60S,
           false
-        );
+        ,"0x");
       let receipt = await tx.wait();
       let event = receipt.logs.find((log) => {
         try {
@@ -2078,7 +2078,7 @@ describe("BondingV5", function () {
         false,
         ANTI_SNIPER_60S,
         false // 500 = 5.00%
-      );
+      ,"0x");
       receipt = await tx.wait();
       event = receipt.logs.find((log) => {
         try {
@@ -2123,7 +2123,7 @@ describe("BondingV5", function () {
           true,
           ANTI_SNIPER_60S,
           false
-        );
+        ,"0x");
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
         try {
@@ -2169,7 +2169,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_60S,
           false
-        )
+        ,"0x")
       ).to.be.revertedWithCustomError(bondingV5, "LaunchModeNotEnabled");
     });
 
@@ -2199,7 +2199,7 @@ describe("BondingV5", function () {
         true,
         ANTI_SNIPER_60S,
         false // 400 = 4.00%
-      );
+      ,"0x");
 
       const receipt = await tx.wait();
       expect(receipt).to.not.be.undefined;
@@ -2231,7 +2231,7 @@ describe("BondingV5", function () {
         true,
         ANTI_SNIPER_60S,
         false // 500 = 5.00%
-      );
+      ,"0x");
 
       const receipt = await tx.wait();
       expect(receipt).to.not.be.undefined;
@@ -2264,7 +2264,7 @@ describe("BondingV5", function () {
           true,
           ANTI_SNIPER_60S,
           false
-        );
+        ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -2307,7 +2307,7 @@ describe("BondingV5", function () {
         true,
         ANTI_SNIPER_60S,
         false // 400 = 4.00%
-      );
+      ,"0x");
 
       const receipt = await tx.wait();
       expect(receipt).to.not.be.undefined;
@@ -2339,7 +2339,7 @@ describe("BondingV5", function () {
         true,
         ANTI_SNIPER_60S,
         false // 500 = 5.00%
-      );
+      ,"0x");
 
       const receipt = await tx.wait();
       expect(receipt).to.not.be.undefined;
@@ -2372,7 +2372,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_60S,
           false // 600 = 6.00% > 5% max
-        )
+        ,"0x")
       ).to.be.revertedWithCustomError(bondingConfig, "AirdropBipsExceedsMax");
     });
   });
@@ -2407,7 +2407,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_NONE,
           false
-        );
+        ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -2451,7 +2451,7 @@ describe("BondingV5", function () {
         false,
         ANTI_SNIPER_98M,
         true // MAX_AIRDROP_BIPS = 500 (5.00%)
-      );
+      ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -2533,7 +2533,7 @@ describe("BondingV5", function () {
             tc.needAcf,
             tc.antiSniper,
             tc.is60days
-          );
+          ,"0x");
 
         const receipt = await tx.wait();
         const event = receipt.logs.find((log) => {
@@ -2587,7 +2587,7 @@ describe("BondingV5", function () {
         false,
         ANTI_SNIPER_60S,
         true // 500 = 5.00%
-      );
+      ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -2634,7 +2634,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_60S,
           false
-        );
+        ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -2685,7 +2685,7 @@ describe("BondingV5", function () {
         false,
         ANTI_SNIPER_60S,
         true // isProject60days
-      );
+      ,"0x");
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
         try {
@@ -2732,7 +2732,7 @@ describe("BondingV5", function () {
         false,
         ANTI_SNIPER_98M,
         true // 500 = 5.00%
-      );
+      ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -2790,7 +2790,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_60S,
           false
-        );
+        ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -2909,7 +2909,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_60S,
           false
-        );
+        ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -2971,7 +2971,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_60S,
           false
-        );
+        ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -3101,7 +3101,7 @@ describe("BondingV5", function () {
         true,
         ANTI_SNIPER_98M,
         true
-      );
+      ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -3356,7 +3356,7 @@ describe("BondingV5", function () {
           true,
           ANTI_SNIPER_60S,
           false
-        );
+        ,"0x");
 
       const feeToBalanceAfter = await virtualToken.balanceOf(owner.address);
       const feeCollected = feeToBalanceAfter - feeToBalanceBefore;
@@ -3394,7 +3394,7 @@ describe("BondingV5", function () {
           false,
           ANTI_SNIPER_60S,
           false
-        );
+        ,"0x");
 
       const feeToBalanceAfter = await virtualToken.balanceOf(owner.address);
       const feeCollected = feeToBalanceAfter - feeToBalanceBefore;
@@ -3436,7 +3436,7 @@ describe("BondingV5", function () {
         false,
         ANTI_SNIPER_60S,
         false // 500 = 5.00%
-      );
+      ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
@@ -3487,7 +3487,7 @@ describe("BondingV5", function () {
         true,
         ANTI_SNIPER_60S,
         false // 400 = 4.00%
-      );
+      ,"0x");
 
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {

--- a/test/launchpadv5/bondingV5DrainLiquidity.js
+++ b/test/launchpadv5/bondingV5DrainLiquidity.js
@@ -37,7 +37,7 @@ async function preLaunchProject60daysP60(
     false,
     ANTI_SNIPER_60S,
     true
-  );
+  ,"0x");
   const receipt = await tx.wait();
   const event = receipt.logs.find((log) => {
     try {
@@ -164,7 +164,7 @@ describe("BondingV5 / FRouterV3 — drain liquidity (V5 suite)", function () {
         false,
         ANTI_SNIPER_60S,
         false
-      );
+      ,"0x");
       const receipt = await tx.wait();
       const event = receipt.logs.find((log) => {
         try {

--- a/test/launchpadv5/bondingV5FeeDelegation.js
+++ b/test/launchpadv5/bondingV5FeeDelegation.js
@@ -1,0 +1,153 @@
+/**
+ * BondingV5 `extParams` V1 encodes optional `abi.encode(bool isFeeDelegation)` (same flag the app calls fee delegation).
+ */
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+const {
+  loadFixture,
+} = require("@nomicfoundation/hardhat-toolbox/network-helpers");
+
+const { START_TIME_DELAY } = require("../launchpadv2/const.js");
+const { setupV2V3TaxComparisonTest } = require("./bondingV5Tax.fixture.js");
+
+const LAUNCH_MODE_NORMAL = 0;
+const ANTI_SNIPER_60S = 1;
+
+/** @returns {Promise<string>} hex `extParams` with first word = canonical ABI-encoded bool */
+function encodeFeeDelegationFlag(isFeeDelegation) {
+  return ethers.AbiCoder.defaultAbiCoder().encode(["bool"], [isFeeDelegation]);
+}
+
+async function feeDelegationFixture() {
+  return setupV2V3TaxComparisonTest({ includeBondingV4: false });
+}
+
+describe("BondingV5 extParams — isFeeDelegation (fee delegation)", function () {
+  let contracts;
+  /** @type {import('ethers').Signer} */
+  let owner;
+  /** @type {import('ethers').Signer} */
+  let user2;
+
+  before(async function () {
+    const setup = await loadFixture(feeDelegationFixture);
+    contracts = setup.contracts;
+    owner = setup.accounts.owner;
+    user2 = setup.accounts.user2;
+  });
+
+  async function preLaunchWithExtParams(extParamsHex) {
+    const { bondingV5, virtualToken, fFactoryV3 } = contracts;
+
+    await virtualToken
+      .connect(user2)
+      .approve(await bondingV5.getAddress(), ethers.MaxUint256);
+
+    const purchaseAmount = ethers.parseEther("1000");
+    const startTime = (await time.latest()) + START_TIME_DELAY + 1;
+
+    const tx = await bondingV5.connect(user2).preLaunch(
+      "FeeDel Token",
+      "FDEL",
+      [0, 1, 2],
+      "desc",
+      "https://example.com/i.png",
+      ["", "", "", ""],
+      purchaseAmount,
+      startTime,
+      LAUNCH_MODE_NORMAL,
+      0,
+      false,
+      ANTI_SNIPER_60S,
+      false,
+      extParamsHex
+    );
+
+    const receipt = await tx.wait();
+    const event = receipt.logs.find((log) => {
+      try {
+        return bondingV5.interface.parseLog(log)?.name === "PreLaunched";
+      } catch {
+        return false;
+      }
+    });
+    const tokenAddress = bondingV5.interface.parseLog(event).args.token;
+    const pairAddress = await fFactoryV3.getPair(
+      tokenAddress,
+      await virtualToken.getAddress()
+    );
+
+    return { tokenAddress, pairAddress, startTime };
+  }
+
+  it("Should store isFeeDelegation true when extParams encodes bool true", async function () {
+    const { bondingV5 } = contracts;
+
+    const extParams = encodeFeeDelegationFlag(true);
+    const { tokenAddress } = await preLaunchWithExtParams(extParams);
+
+    expect(await bondingV5.isFeeDelegation(tokenAddress)).to.equal(true);
+  });
+
+  it("Should store isFeeDelegation false when extParams is empty", async function () {
+    const { bondingV5 } = contracts;
+
+    const { tokenAddress } = await preLaunchWithExtParams("0x");
+
+    expect(await bondingV5.isFeeDelegation(tokenAddress)).to.equal(false);
+  });
+
+  it("Should store isFeeDelegation false when extParams encodes bool false", async function () {
+    const { bondingV5 } = contracts;
+
+    const extParams = encodeFeeDelegationFlag(false);
+    const { tokenAddress } = await preLaunchWithExtParams(extParams);
+
+    expect(await bondingV5.isFeeDelegation(tokenAddress)).to.equal(false);
+  });
+
+  it("Should treat non-canonical bool word as false", async function () {
+    const { bondingV5 } = contracts;
+
+    const badWord = ethers.zeroPadValue(ethers.toBeHex(2), 32);
+    const extParams = ethers.hexlify(badWord);
+
+    const { tokenAddress } = await preLaunchWithExtParams(extParams);
+
+    expect(await bondingV5.isFeeDelegation(tokenAddress)).to.equal(false);
+  });
+
+  it("Should still read isFeeDelegation true after launch when caller is privileged", async function () {
+    const { bondingV5, bondingConfig } = contracts;
+
+    const extParams = encodeFeeDelegationFlag(true);
+    const { tokenAddress, startTime } = await preLaunchWithExtParams(extParams);
+
+    expect(await bondingV5.isFeeDelegation(tokenAddress)).to.equal(true);
+
+    await bondingConfig.connect(owner).setPrivilegedLauncher(user2.address, true);
+
+    await time.increaseTo(startTime + 1);
+    await bondingV5.connect(user2).launch(tokenAddress);
+
+    expect(await bondingV5.isFeeDelegation(tokenAddress)).to.equal(true);
+
+    await bondingConfig.connect(owner).setPrivilegedLauncher(user2.address, false);
+  });
+
+  it("Should revert launch for fee-delegation token when caller is not privileged", async function () {
+    const { bondingV5, bondingConfig } = contracts;
+
+    await bondingConfig.connect(owner).setPrivilegedLauncher(user2.address, false);
+
+    const extParams = encodeFeeDelegationFlag(true);
+    const { tokenAddress, startTime } = await preLaunchWithExtParams(extParams);
+
+    await time.increaseTo(startTime + 1);
+
+    await expect(
+      bondingV5.connect(user2).launch(tokenAddress)
+    ).to.be.revertedWithCustomError(bondingV5, "UnauthorizedLauncher");
+  });
+});

--- a/test/launchpadv5/bondingV5Tax.js
+++ b/test/launchpadv5/bondingV5Tax.js
@@ -1,112 +1,37 @@
+/**
+ * BondingV5-only tax tests (no BondingV4 / legacy V2 curve).
+ * Fixture deploys BondingV5 + AgentTaxV2; BondingV4 is not deployed.
+ */
 const { expect } = require("chai");
-const { ethers, upgrades } = require("hardhat");
+const { ethers } = require("hardhat");
 const { time } = require("@nomicfoundation/hardhat-network-helpers");
 const {
   loadFixture,
 } = require("@nomicfoundation/hardhat-toolbox/network-helpers");
 
-const {
-  START_TIME_DELAY,
-  INITIAL_SUPPLY,
-  TBA_SALT,
-  TBA_IMPLEMENTATION,
-  DAO_VOTING_PERIOD,
-  DAO_THRESHOLD,
-  BUY_TAX,
-  SELL_TAX,
-  ANTI_SNIPER_BUY_TAX_START_VALUE,
-  FFactoryV2_TAX_VAULT,
-  FFactoryV2_ANTI_SNIPER_TAX_VAULT,
-  ASSET_RATE,
-  GRAD_THRESHOLD,
-  MAX_TX,
-} = require("../launchpadv2/const.js");
+const { START_TIME_DELAY, BUY_TAX } = require("../launchpadv2/const.js");
 
 const { setupV2V3TaxComparisonTest } = require("./bondingV5Tax.fixture.js");
 
-// BondingV4 launch mode constants
-const LAUNCH_MODE_NORMAL_V4 = 0;
-
-// BondingV5 launch mode constants
 const LAUNCH_MODE_NORMAL = 0;
-
-// Anti-sniper tax type constants
-const ANTI_SNIPER_NONE = 0;
 const ANTI_SNIPER_60S = 1;
 
-// Reserve supply parameters
-const MAX_AIRDROP_BIPS = 500;
-const MAX_TOTAL_RESERVED_BIPS = 5500;
-const ACF_RESERVED_BIPS = 5000;
+async function bondingV5TaxFixture() {
+  return setupV2V3TaxComparisonTest({ includeBondingV4: false });
+}
 
-// Fee structure
-const NORMAL_LAUNCH_FEE = ethers.parseEther("100");
-const ACF_FEE = ethers.parseEther("10");
-
-// Bonding curve params
-const FAKE_INITIAL_VIRTUAL_LIQ = ethers.parseEther("6300");
-const TARGET_REAL_VIRTUAL = ethers.parseEther("42000");
-
-describe("V2 vs V3 Tax Attribution Comparison", function () {
-  let setup;
+describe("BondingV5 tax flow (AgentTaxV2)", function () {
   let contracts, accounts;
-  let v2TokenAddress, v2PairAddress;
-  let v3TokenAddress, v3PairAddress;
+  /** BondingV5-launched agent token + pair */
+  let tokenAddress, pairAddress;
 
   before(async function () {
-    setup = await loadFixture(setupV2V3TaxComparisonTest);
+    const setup = await loadFixture(bondingV5TaxFixture);
     contracts = setup.contracts;
     accounts = setup.accounts;
   });
 
-  describe("Phase 1: Create V2 Token via BondingV4", function () {
-    it("Should create V2 token with AgentTokenV2 implementation", async function () {
-      const { bondingV4, virtualToken, fFactoryV2, fRouterV2, agentFactoryV6 } = contracts;
-      const { user1 } = accounts;
-
-      // Verify AgentFactoryV6 is using V2 implementation
-      const currentImpl = await agentFactoryV6.tokenImplementation();
-      expect(currentImpl).to.equal(await contracts.agentTokenV2Impl.getAddress());
-
-      // Approve tokens
-      await virtualToken.connect(user1).approve(await bondingV4.getAddress(), ethers.MaxUint256);
-      await virtualToken.connect(user1).approve(await fRouterV2.getAddress(), ethers.MaxUint256);
-
-      const tokenName = "V2 Test Token";
-      const tokenTicker = "V2TEST";
-      const cores = [0, 1, 2];
-      const description = "V2 Token for tax comparison";
-      const image = "https://example.com/v2.png";
-      const urls = ["https://twitter.com/v2", "https://t.me/v2", "https://youtube.com/v2", "https://example.com/v2"];
-      const purchaseAmount = ethers.parseEther("1000");
-      const startTime = (await time.latest()) + START_TIME_DELAY + 1;
-
-      // PreLaunch V2 token
-      const tx = await bondingV4.connect(user1).preLaunch(
-        tokenName, tokenTicker, cores, description, image, urls,
-        purchaseAmount, startTime, LAUNCH_MODE_NORMAL_V4
-      );
-
-      const receipt = await tx.wait();
-      const event = receipt.logs.find((log) => {
-        try { return bondingV4.interface.parseLog(log)?.name === "PreLaunched"; } catch (e) { return false; }
-      });
-      v2TokenAddress = bondingV4.interface.parseLog(event).args.token;
-      v2PairAddress = await fFactoryV2.getPair(v2TokenAddress, await virtualToken.getAddress());
-
-      expect(v2TokenAddress).to.not.equal(ethers.ZeroAddress);
-      expect(v2PairAddress).to.not.equal(ethers.ZeroAddress);
-
-      // Wait and launch
-      await time.increaseTo(startTime + 1);
-      await bondingV4.launch(v2TokenAddress);
-
-      console.log("V2 Token created:", v2TokenAddress);
-      console.log("V2 Pair:", v2PairAddress);
-    });
-  });
-
-  describe("Phase 2: AgentFactoryV7 + AgentTokenV4 via BondingV5", function () {
+  describe("AgentFactoryV7 + BondingV5 preLaunch → launch", function () {
     it("Should use AgentFactoryV7 with AgentTokenV4 implementation for BondingV5", async function () {
       const { agentFactoryV7, agentTokenV4Impl } = contracts;
 
@@ -115,308 +40,246 @@ describe("V2 vs V3 Tax Attribution Comparison", function () {
       );
     });
 
-    it("Should create V4 token with AgentTokenV4 implementation", async function () {
-      const { bondingV5, virtualToken, fFactoryV3, fRouterV3, agentTax } = contracts;
+    it("Should create AgentTokenV4 via BondingV5 preLaunch + launch", async function () {
+      const { bondingV5, virtualToken, fFactoryV3, fRouterV3, agentTax } =
+        contracts;
       const { user2 } = accounts;
 
-      // No need to switch router - BondingV5 uses FFactoryV3 which is already configured with FRouterV3
-      // This is cleaner than reusing FFactoryV2 because:
-      // 1. Frontend can determine router by factory (BondingV5 -> FFactoryV3 -> FRouterV3)
-      // 2. No risk of BondingV4 tokens accidentally getting FRouterV3
+      await virtualToken
+        .connect(user2)
+        .approve(await bondingV5.getAddress(), ethers.MaxUint256);
+      await virtualToken
+        .connect(user2)
+        .approve(await fRouterV3.getAddress(), ethers.MaxUint256);
 
-      // Approve tokens
-      await virtualToken.connect(user2).approve(await bondingV5.getAddress(), ethers.MaxUint256);
-      await virtualToken.connect(user2).approve(await fRouterV3.getAddress(), ethers.MaxUint256);
-
-      const tokenName = "V3 Test Token";
-      const tokenTicker = "V3TEST";
-      const cores = [0, 1, 2];
-      const description = "V3 Token for tax comparison";
-      const image = "https://example.com/v3.png";
-      const urls = ["https://twitter.com/v3", "https://t.me/v3", "https://youtube.com/v3", "https://example.com/v3"];
       const purchaseAmount = ethers.parseEther("1000");
       const startTime = (await time.latest()) + START_TIME_DELAY + 1;
 
-      // PreLaunch V3 token
       const tx = await bondingV5.connect(user2).preLaunch(
-        tokenName, tokenTicker, cores, description, image, urls,
-        purchaseAmount, startTime, LAUNCH_MODE_NORMAL, 0, false, ANTI_SNIPER_60S, false
-          );
+        "BondingV5 Tax Token",
+        "BV5TX",
+        [0, 1, 2],
+        "BondingV5 AgentTax integration",
+        "https://example.com/v5.png",
+        ["https://twitter.com/x", "", "", ""],
+        purchaseAmount,
+        startTime,
+        LAUNCH_MODE_NORMAL,
+        0,
+        false,
+        ANTI_SNIPER_60S,
+        false,
+        "0x"
+      );
 
-        const receipt = await tx.wait();
-        const event = receipt.logs.find((log) => {
-        try { return bondingV5.interface.parseLog(log)?.name === "PreLaunched"; } catch (e) { return false; }
+      const receipt = await tx.wait();
+      const event = receipt.logs.find((log) => {
+        try {
+          return bondingV5.interface.parseLog(log)?.name === "PreLaunched";
+        } catch (e) {
+          return false;
+        }
       });
-      v3TokenAddress = bondingV5.interface.parseLog(event).args.token;
-      v3PairAddress = await fFactoryV3.getPair(v3TokenAddress, await virtualToken.getAddress());
+      tokenAddress = bondingV5.interface.parseLog(event).args.token;
+      pairAddress = await fFactoryV3.getPair(
+        tokenAddress,
+        await virtualToken.getAddress()
+      );
 
-      expect(v3TokenAddress).to.not.equal(ethers.ZeroAddress);
-      expect(v3PairAddress).to.not.equal(ethers.ZeroAddress);
+      expect(tokenAddress).to.not.equal(ethers.ZeroAddress);
+      expect(pairAddress).to.not.equal(ethers.ZeroAddress);
 
-      // Verify TokenRegistered event was emitted during preLaunch (not launch)
       const tokenRegisteredEvent = receipt.logs.find((log) => {
-        try { return agentTax.interface.parseLog(log)?.name === "TokenRegistered"; } catch (e) { return false; }
+        try {
+          return agentTax.interface.parseLog(log)?.name === "TokenRegistered";
+        } catch (e) {
+          return false;
+        }
       });
       expect(tokenRegisteredEvent).to.not.be.undefined;
 
-      // Verify creator info is recorded in AgentTax
-      const recipient = await agentTax.tokenRecipients(v3TokenAddress);
+      const recipient = await agentTax.tokenRecipients(tokenAddress);
       expect(recipient.creator).to.equal(user2.address);
 
-      // Wait and launch
       await time.increaseTo(startTime + 1);
-      await bondingV5.launch(v3TokenAddress);
+      await bondingV5.launch(tokenAddress);
 
-      console.log("V3 Token created:", v3TokenAddress);
-      console.log("V3 Pair:", v3PairAddress);
+      console.log("BondingV5 token:", tokenAddress);
+      console.log("Pair:", pairAddress);
     });
   });
 
-  describe("Phase 3: V2 Token Tax Flow (tax-listener simulation)", function () {
-    it("V2 BUY: Tax should be sent directly to taxVault (tax-listener would process)", async function () {
-      const { bondingV4, virtualToken, fRouterV2, agentTax } = contracts;
-        const { user1 } = accounts;
-
-      // BondingV4 uses its stored FRouterV2 reference - no need to switch FFactoryV2.router
-      await virtualToken.connect(user1).approve(await bondingV4.getAddress(), ethers.MaxUint256);
-      await virtualToken.connect(user1).approve(await fRouterV2.getAddress(), ethers.MaxUint256);
-
-      const buyAmount = ethers.parseEther("500");
-      const agentTaxAddress = await agentTax.getAddress();
-
-      const tx = await bondingV4.connect(user1).buy(buyAmount, v2TokenAddress, 0, (await time.latest()) + 300);
-        const receipt = await tx.wait();
-
-      // Find Transfer events to AgentTax (taxVault)
-      const transfersToTax = receipt.logs.filter((log) => {
-        try {
-          const parsed = virtualToken.interface.parseLog(log);
-          return parsed?.name === "Transfer" && parsed.args.to === agentTaxAddress;
-        } catch (e) { return false; }
-      });
-
-      expect(transfersToTax.length).to.be.gt(0);
-
-      // For V2 BUY: tax comes from buyer directly
-      // Tax-listener would find this via fallback (Swap event matching)
-      let foundBuyerTransfer = false;
-      for (const log of transfersToTax) {
-        const parsed = virtualToken.interface.parseLog(log);
-        console.log("V2 BUY tax transfer from:", parsed.args.from, "amount:", ethers.formatEther(parsed.args.value));
-        
-        // Assert: tax transfer comes from buyer (user1)
-        if (parsed.args.from.toLowerCase() === user1.address.toLowerCase()) {
-          foundBuyerTransfer = true;
-          console.log("  -> Tax from buyer (user1) - tax-listener uses fallback to find agent");
-        }
-      }
-      expect(foundBuyerTransfer).to.be.true;
-
-      // V2 should NOT have TaxDeposited event (no depositTax called)
-      const taxDepositedEvent = receipt.logs.find((log) => {
-        try { return agentTax.interface.parseLog(log)?.name === "TaxDeposited"; } catch (e) { return false; }
-      });
-      expect(taxDepositedEvent).to.be.undefined;
-
-      // V2 should NOT have tokenTaxAmounts recorded
-      const v2TaxAmounts = await agentTax.tokenTaxAmounts(v2TokenAddress);
-      expect(v2TaxAmounts.amountCollected).to.equal(0n);
-    });
-
-    it("V2 SELL: Tax should be sent from preTokenPair to taxVault", async function () {
-      const { bondingV4, virtualToken, fRouterV2, agentTax } = contracts;
-        const { user1 } = accounts;
-
-      // Get some V2 tokens first by buying
-      await virtualToken.connect(user1).approve(await bondingV4.getAddress(), ethers.MaxUint256);
-      await bondingV4.connect(user1).buy(ethers.parseEther("1000"), v2TokenAddress, 0, (await time.latest()) + 300);
-
-      // Get token contract and approve for sell
-      const v2Token = await ethers.getContractAt("AgentTokenV2", v2TokenAddress);
-      const tokenBalance = await v2Token.balanceOf(user1.address);
-      await v2Token.connect(user1).approve(await bondingV4.getAddress(), tokenBalance);
-      await v2Token.connect(user1).approve(await fRouterV2.getAddress(), tokenBalance);
-
-      const agentTaxAddress = await agentTax.getAddress();
-      const sellAmount = tokenBalance / 2n;
-
-      const tx = await bondingV4.connect(user1).sell(sellAmount, v2TokenAddress, 0, (await time.latest()) + 300);
-        const receipt = await tx.wait();
-
-      // Find Transfer events to AgentTax
-      const transfersToTax = receipt.logs.filter((log) => {
-        try {
-          const parsed = virtualToken.interface.parseLog(log);
-          return parsed?.name === "Transfer" && parsed.args.to === agentTaxAddress;
-        } catch (e) { return false; }
-      });
-
-      expect(transfersToTax.length).to.be.gt(0);
-
-      // For V2 SELL: tax comes from preTokenPair
-      // Tax-listener would process this (log.from matches preTokenPair)
-      let foundPairTransfer = false;
-      for (const log of transfersToTax) {
-        const parsed = virtualToken.interface.parseLog(log);
-        console.log("V2 SELL tax transfer from:", parsed.args.from, "amount:", ethers.formatEther(parsed.args.value));
-        
-        // Assert: tax transfer comes from preTokenPair
-        if (parsed.args.from.toLowerCase() === v2PairAddress.toLowerCase()) {
-          foundPairTransfer = true;
-          console.log("  -> Tax from preTokenPair - tax-listener would process directly");
-        }
-      }
-      expect(foundPairTransfer).to.be.true;
-
-      // V2 should NOT have TaxDeposited event
-      const taxDepositedEvent = receipt.logs.find((log) => {
-        try { return agentTax.interface.parseLog(log)?.name === "TaxDeposited"; } catch (e) { return false; }
-      });
-      expect(taxDepositedEvent).to.be.undefined;
-    });
-  });
-
-  describe("Phase 4: V3 Token Tax Flow (on-chain attribution)", function () {
-    // BondingV5 uses its stored FRouterV3 reference - no need to switch FFactoryV2.router
-
-    it("V3 BUY: Should emit TaxDeposited and record in tokenTaxAmounts", async function () {
+  describe("BUY / SELL tax attribution on-chain", function () {
+    it("BUY: Should emit TaxDeposited and record tokenTaxAmounts", async function () {
       const { bondingV5, virtualToken, fRouterV3, agentTax } = contracts;
       const { user1 } = accounts;
 
-      await virtualToken.connect(user1).approve(await bondingV5.getAddress(), ethers.MaxUint256);
-      await virtualToken.connect(user1).approve(await fRouterV3.getAddress(), ethers.MaxUint256);
+      await virtualToken
+        .connect(user1)
+        .approve(await bondingV5.getAddress(), ethers.MaxUint256);
+      await virtualToken
+        .connect(user1)
+        .approve(await fRouterV3.getAddress(), ethers.MaxUint256);
 
       const buyAmount = ethers.parseEther("500");
       const expectedTax = (buyAmount * BigInt(BUY_TAX)) / 100n;
 
-      const taxBefore = await agentTax.tokenTaxAmounts(v3TokenAddress);
+      const taxBefore = await agentTax.tokenTaxAmounts(tokenAddress);
 
-      const tx = await bondingV5.connect(user1).buy(buyAmount, v3TokenAddress, 0, (await time.latest()) + 300);
+      const tx = await bondingV5
+        .connect(user1)
+        .buy(buyAmount, tokenAddress, 0, (await time.latest()) + 300);
       const receipt = await tx.wait();
 
-      // V3 SHOULD have TaxDeposited event
       const taxDepositedEvent = receipt.logs.find((log) => {
-        try { return agentTax.interface.parseLog(log)?.name === "TaxDeposited"; } catch (e) { return false; }
+        try {
+          return agentTax.interface.parseLog(log)?.name === "TaxDeposited";
+        } catch (e) {
+          return false;
+        }
       });
 
       expect(taxDepositedEvent).to.not.be.undefined;
       const parsedEvent = agentTax.interface.parseLog(taxDepositedEvent);
-      expect(parsedEvent.args.tokenAddress).to.equal(v3TokenAddress);
+      expect(parsedEvent.args.tokenAddress).to.equal(tokenAddress);
       expect(parsedEvent.args.amount).to.equal(expectedTax);
 
-      // V3 SHOULD have tokenTaxAmounts updated
-      const taxAfter = await agentTax.tokenTaxAmounts(v3TokenAddress);
-      expect(taxAfter.amountCollected).to.equal(taxBefore.amountCollected + expectedTax);
+      const taxAfter = await agentTax.tokenTaxAmounts(tokenAddress);
+      expect(taxAfter.amountCollected).to.equal(
+        taxBefore.amountCollected + expectedTax
+      );
 
-      console.log("V3 BUY: TaxDeposited event amount:", ethers.formatEther(parsedEvent.args.amount));
-      console.log("V3 BUY: tokenTaxAmounts.amountCollected:", ethers.formatEther(taxAfter.amountCollected));
+      console.log(
+        "BUY TaxDeposited:",
+        ethers.formatEther(parsedEvent.args.amount)
+      );
+      console.log(
+        "tokenTaxAmounts.amountCollected:",
+        ethers.formatEther(taxAfter.amountCollected)
+      );
     });
 
-    it("V3 SELL: Should emit TaxDeposited and record in tokenTaxAmounts", async function () {
+    it("SELL: Should emit TaxDeposited and record tokenTaxAmounts", async function () {
       const { bondingV5, virtualToken, fRouterV3, agentTax } = contracts;
       const { user1 } = accounts;
 
-      // Get some V3 tokens first
-      await virtualToken.connect(user1).approve(await bondingV5.getAddress(), ethers.MaxUint256);
-      await virtualToken.connect(user1).approve(await fRouterV3.getAddress(), ethers.MaxUint256);
-      await bondingV5.connect(user1).buy(ethers.parseEther("1000"), v3TokenAddress, 0, (await time.latest()) + 300);
+      await virtualToken
+        .connect(user1)
+        .approve(await bondingV5.getAddress(), ethers.MaxUint256);
+      await virtualToken
+        .connect(user1)
+        .approve(await fRouterV3.getAddress(), ethers.MaxUint256);
+      await bondingV5
+        .connect(user1)
+        .buy(ethers.parseEther("1000"), tokenAddress, 0, (await time.latest()) + 300);
 
-      // Get token contract and approve for sell (V4 token uses AgentTokenV4)
-      const v3Token = await ethers.getContractAt("AgentTokenV4", v3TokenAddress);
-      const tokenBalance = await v3Token.balanceOf(user1.address);
-      await v3Token.connect(user1).approve(await bondingV5.getAddress(), tokenBalance);
-      await v3Token.connect(user1).approve(await fRouterV3.getAddress(), tokenBalance);
+      const agentToken = await ethers.getContractAt("AgentTokenV4", tokenAddress);
+      const tokenBalance = await agentToken.balanceOf(user1.address);
+      await agentToken
+        .connect(user1)
+        .approve(await bondingV5.getAddress(), tokenBalance);
+      await agentToken
+        .connect(user1)
+        .approve(await fRouterV3.getAddress(), tokenBalance);
 
-      const taxBefore = await agentTax.tokenTaxAmounts(v3TokenAddress);
+      const taxBefore = await agentTax.tokenTaxAmounts(tokenAddress);
       const sellAmount = tokenBalance / 2n;
 
-      const tx = await bondingV5.connect(user1).sell(sellAmount, v3TokenAddress, 0, (await time.latest()) + 300);
+      const tx = await bondingV5
+        .connect(user1)
+        .sell(sellAmount, tokenAddress, 0, (await time.latest()) + 300);
       const receipt = await tx.wait();
 
-      // V3 SHOULD have TaxDeposited event
       const taxDepositedEvent = receipt.logs.find((log) => {
-        try { return agentTax.interface.parseLog(log)?.name === "TaxDeposited"; } catch (e) { return false; }
+        try {
+          return agentTax.interface.parseLog(log)?.name === "TaxDeposited";
+        } catch (e) {
+          return false;
+        }
       });
 
       expect(taxDepositedEvent).to.not.be.undefined;
       const parsedEvent = agentTax.interface.parseLog(taxDepositedEvent);
-      expect(parsedEvent.args.tokenAddress).to.equal(v3TokenAddress);
+      expect(parsedEvent.args.tokenAddress).to.equal(tokenAddress);
       expect(parsedEvent.args.amount).to.be.gt(0);
 
-      // V3 SHOULD have tokenTaxAmounts updated
-      const taxAfter = await agentTax.tokenTaxAmounts(v3TokenAddress);
+      const taxAfter = await agentTax.tokenTaxAmounts(tokenAddress);
       expect(taxAfter.amountCollected).to.be.gt(taxBefore.amountCollected);
 
-      console.log("V3 SELL: TaxDeposited event amount:", ethers.formatEther(parsedEvent.args.amount));
-      console.log("V3 SELL: tokenTaxAmounts.amountCollected:", ethers.formatEther(taxAfter.amountCollected));
+      console.log(
+        "SELL TaxDeposited:",
+        ethers.formatEther(parsedEvent.args.amount)
+      );
+      console.log(
+        "tokenTaxAmounts.amountCollected:",
+        ethers.formatEther(taxAfter.amountCollected)
+      );
     });
 
-    it("V3: Tax transfers should NOT be processable by tax-listener (from FRouterV3)", async function () {
+    it("Tax transfers from FRouterV3 should not match preTokenPair (tax-listener heuristic)", async function () {
       const { bondingV5, virtualToken, fRouterV3, agentTax } = contracts;
       const { user2 } = accounts;
 
-      await virtualToken.connect(user2).approve(await bondingV5.getAddress(), ethers.MaxUint256);
-      await virtualToken.connect(user2).approve(await fRouterV3.getAddress(), ethers.MaxUint256);
+      await virtualToken
+        .connect(user2)
+        .approve(await bondingV5.getAddress(), ethers.MaxUint256);
+      await virtualToken
+        .connect(user2)
+        .approve(await fRouterV3.getAddress(), ethers.MaxUint256);
 
-      const tx = await bondingV5.connect(user2).buy(ethers.parseEther("100"), v3TokenAddress, 0, (await time.latest()) + 300);
+      const tx = await bondingV5
+        .connect(user2)
+        .buy(ethers.parseEther("100"), tokenAddress, 0, (await time.latest()) + 300);
       const receipt = await tx.wait();
 
       const agentTaxAddress = await agentTax.getAddress();
       const fRouterV3Address = await fRouterV3.getAddress();
 
-      // Find Transfer events to AgentTax
       const transfersToTax = receipt.logs.filter((log) => {
         try {
           const parsed = virtualToken.interface.parseLog(log);
-          return parsed?.name === "Transfer" && parsed.args.to === agentTaxAddress;
-        } catch (e) { return false; }
+          return (
+            parsed?.name === "Transfer" && parsed.args.to === agentTaxAddress
+          );
+        } catch (e) {
+          return false;
+        }
       });
 
-      // For V3: transfers to AgentTax come from FRouterV3 (via depositTax)
-      // Tax-listener checks: lpSource, uniV2PoolAddr, preTokenPair - FRouterV3 is none of these
       for (const log of transfersToTax) {
         const parsed = virtualToken.interface.parseLog(log);
         const fromAddress = parsed.args.from;
+        const wouldTaxListenerProcess =
+          fromAddress.toLowerCase() === pairAddress.toLowerCase();
 
-        // Tax-listener would check if fromAddress matches known LP addresses
-        const wouldTaxListenerProcess = 
-          fromAddress.toLowerCase() === v3PairAddress.toLowerCase(); // preTokenPair
-
-        // FRouterV3 is NOT preTokenPair, so tax-listener would NOT process directly
-        // (though fallback might find Swap event - that's why tax-listener needs to skip BondingV5 tokens)
         if (fromAddress.toLowerCase() === fRouterV3Address.toLowerCase()) {
           expect(wouldTaxListenerProcess).to.be.false;
-          console.log("V3: Tax transfer from FRouterV3 - tax-listener would NOT process by log.from");
+          console.log(
+            "Tax transfer from FRouterV3 — not classifiable as preTokenPair by from-address alone"
+          );
         }
       }
     });
   });
 
-  describe("Phase 5: Summary Comparison", function () {
-    it("Should show V2 vs V3 tax attribution differences", async function () {
+  describe("Summary", function () {
+    it("Should record positive on-chain tax for the BondingV5 token", async function () {
       const { agentTax } = contracts;
 
-      const v2TaxAmounts = await agentTax.tokenTaxAmounts(v2TokenAddress);
-      const v3TaxAmounts = await agentTax.tokenTaxAmounts(v3TokenAddress);
+      const amounts = await agentTax.tokenTaxAmounts(tokenAddress);
+      expect(amounts.amountCollected).to.be.gt(0n);
 
-      console.log("\n=== V2 vs V3 Tax Attribution Summary ===");
-      console.log("V2 Token:", v2TokenAddress);
-      console.log("  - tokenTaxAmounts.amountCollected:", ethers.formatEther(v2TaxAmounts.amountCollected), "VIRTUAL");
-      console.log("  - Tax tracking: OFF-CHAIN (tax-listener required)");
+      const recipient = await agentTax.tokenRecipients(tokenAddress);
+      expect(recipient.creator).to.not.equal(ethers.ZeroAddress);
 
-      console.log("\nV3 Token:", v3TokenAddress);
-      console.log("  - tokenTaxAmounts.amountCollected:", ethers.formatEther(v3TaxAmounts.amountCollected), "VIRTUAL");
-      console.log("  - Tax tracking: ON-CHAIN (no tax-listener needed)");
-
-      // V2 should have 0 on-chain tax recorded
-      expect(v2TaxAmounts.amountCollected).to.equal(0n);
-      // V3 should have tax recorded on-chain
-      expect(v3TaxAmounts.amountCollected).to.be.gt(0n);
-
-      // V3 should also have creator recorded
-      const v3Recipient = await agentTax.tokenRecipients(v3TokenAddress);
-      expect(v3Recipient.creator).to.not.equal(ethers.ZeroAddress);
-      console.log("  - Creator:", v3Recipient.creator);
+      console.log("\n=== BondingV5 AgentTax summary ===");
+      console.log("Token:", tokenAddress);
+      console.log(
+        "amountCollected:",
+        ethers.formatEther(amounts.amountCollected),
+        "VIRTUAL"
+      );
+      console.log("Creator:", recipient.creator);
     });
   });
 });

--- a/test/launchpadv5/taxAccountingAdapter.e2e.js
+++ b/test/launchpadv5/taxAccountingAdapter.e2e.js
@@ -120,7 +120,7 @@ describe("TaxAccountingAdapter E2E (BondingV5 + AgentTokenV4)", function () {
       false,
       ANTI_SNIPER_60S,
       false
-    );
+    ,"0x");
     const receipt = await tx.wait();
     const preEvent = receipt.logs.find((log) => {
       try {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches on-chain launch authorization and tax-recipient update gating for a new launch classification, so mis-encoding `extParams` or incorrect privileged-launcher assumptions could block launches or misroute updates; remaining changes are mostly test/script wiring.
> 
> **Overview**
> Adds a new per-token `isFeeDelegation` flag to `BondingV5` derived from a new `preLaunch` `extParams` calldata extension (V1: `abi.encode(bool)`), persists it on-chain, and treats fee-delegation tokens like other *special launches* by requiring a privileged launcher for `launch()`.
> 
> Extends `AgentTaxV2`’s BondingV5 interface and creator-update gate to include fee-delegation tokens, and updates scripts/tests accordingly (new fee-delegation test, `preLaunch` callsites updated with `"0x"`/encoded ext params, and e2e helpers to encode/interpret the flag).
> 
> Testnet tooling is also updated: introduces `MockPositionDescriptor`, enhances `deployUniswapV3TestnetLiquidity.ts` to optionally reuse/deploy the Uniswap V3 stack and adds `QuoterV2`, and updates `.openzeppelin/base-sepolia.json` with new deployment layouts/addresses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5e728aad6909b10cd750271f24c4848af25d17f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->