### PR TITLE
Fix plamen audit issues

### DIFF
--- a/.openzeppelin/base-sepolia.json
+++ b/.openzeppelin/base-sepolia.json
@@ -55489,6 +55489,638 @@
         "0x7269Bb28F89b2D3120eE3104e1b2dB9A01621C9a",
         "0xf0dc6E31C04994781d6180A2F3AB4ea854C75b48"
       ]
+    },
+    "853fa7fd6fb5ae3ecffa8dca79fbc58102a430bfa953cb0b43a4267ab1c55021": {
+      "address": "0xfabA46F16816F1DDA93aEa3Ee096f06369e85d4a",
+      "txHash": "0x68076bbf25a02365bed46e3fb01868156a1a36d6bd035ef7d10ea76257fe423a",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(IFFactoryV2Minimal)8032",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:95"
+          },
+          {
+            "label": "router",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_contract(IFRouterV3Minimal)8094",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:96"
+          },
+          {
+            "label": "agentFactory",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IAgentFactoryV7Minimal)8159",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:97"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(BondingConfig)2988",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:98"
+          },
+          {
+            "label": "tokenInfo",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_struct(Token)2469_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:100"
+          },
+          {
+            "label": "tokenInfos",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:101"
+          },
+          {
+            "label": "tokenLaunchParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_address,t_struct(LaunchParams)2480_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:107"
+          },
+          {
+            "label": "tokenGradThreshold",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:110"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)151_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)296_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint8)dyn_storage": {
+            "label": "uint8[]",
+            "numberOfBytes": "32"
+          },
+          "t_contract(BondingConfig)2988": {
+            "label": "contract BondingConfig",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IAgentFactoryV7Minimal)8159": {
+            "label": "contract IAgentFactoryV7Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFFactoryV2Minimal)8032": {
+            "label": "contract IFFactoryV2Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFRouterV3Minimal)8094": {
+            "label": "contract IFRouterV3Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_struct(LaunchParams)2480_storage)": {
+            "label": "mapping(address => struct BondingConfig.LaunchParams)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Token)2469_storage)": {
+            "label": "mapping(address => struct BondingConfig.Token)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Data)2430_storage": {
+            "label": "struct BondingConfig.Data",
+            "members": [
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "ticker",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "supply",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "price",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "marketCap",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "liquidity",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "volume",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "volume24H",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "prevPrice",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "10"
+              },
+              {
+                "label": "lastUpdated",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "11"
+              }
+            ],
+            "numberOfBytes": "384"
+          },
+          "t_struct(LaunchParams)2480_storage": {
+            "label": "struct BondingConfig.LaunchParams",
+            "members": [
+              {
+                "label": "launchMode",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "airdropBips",
+                "type": "t_uint16",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "needAcf",
+                "type": "t_bool",
+                "offset": 3,
+                "slot": "0"
+              },
+              {
+                "label": "antiSniperTaxType",
+                "type": "t_uint8",
+                "offset": 4,
+                "slot": "0"
+              },
+              {
+                "label": "isProject60days",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Token)2469_storage": {
+            "label": "struct BondingConfig.Token",
+            "members": [
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "pair",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "agentToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "data",
+                "type": "t_struct(Data)2430_storage",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "description",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "16"
+              },
+              {
+                "label": "cores",
+                "type": "t_array(t_uint8)dyn_storage",
+                "offset": 0,
+                "slot": "17"
+              },
+              {
+                "label": "image",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "18"
+              },
+              {
+                "label": "twitter",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "19"
+              },
+              {
+                "label": "telegram",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "20"
+              },
+              {
+                "label": "youtube",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "21"
+              },
+              {
+                "label": "website",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "22"
+              },
+              {
+                "label": "trading",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "23"
+              },
+              {
+                "label": "tradingOnUniswap",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "23"
+              },
+              {
+                "label": "applicationId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "24"
+              },
+              {
+                "label": "initialPurchase",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "25"
+              },
+              {
+                "label": "virtualId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "26"
+              },
+              {
+                "label": "launchExecuted",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "27"
+              }
+            ],
+            "numberOfBytes": "896"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "b80e1834a2354ea32b7450ade1893f41ca815cd217757b8f4bbe1a61b9a984ee": {
+      "address": "0x059f2ca926FF0b8e0005356734948372Ba1d4e0a",
+      "txHash": "0xd2d0e4c17b2de8b630e365802d20e30640c3316e951e7319a3286ac792b264ae",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(FFactoryV3)10627",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:48"
+          },
+          {
+            "label": "assetToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:49"
+          },
+          {
+            "label": "bondingV5",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IBondingV5ForRouter)12559",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:52"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(IBondingConfigForRouter)12572",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:53"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)296_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(FFactoryV3)10627": {
+            "label": "contract FFactoryV3",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IBondingConfigForRouter)12572": {
+            "label": "contract IBondingConfigForRouter",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IBondingV5ForRouter)12559": {
+            "label": "contract IBondingV5ForRouter",
+            "numberOfBytes": "20"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/base.json
+++ b/.openzeppelin/base.json
@@ -20586,64 +20586,64 @@
             "offset": 0,
             "slot": "0",
             "type": "t_mapping(t_address,t_mapping(t_address,t_address))",
-            "contract": "FFactoryV3",
-            "src": "contracts/launchpadv2/FFactoryV3.sol:26"
+            "contract": "FFactoryV2",
+            "src": "contracts/launchpadv2/FFactoryV2.sol:18"
           },
           {
             "label": "pairs",
             "offset": 0,
             "slot": "1",
             "type": "t_array(t_address)dyn_storage",
-            "contract": "FFactoryV3",
-            "src": "contracts/launchpadv2/FFactoryV3.sol:28"
+            "contract": "FFactoryV2",
+            "src": "contracts/launchpadv2/FFactoryV2.sol:20"
           },
           {
             "label": "router",
             "offset": 0,
             "slot": "2",
             "type": "t_address",
-            "contract": "FFactoryV3",
-            "src": "contracts/launchpadv2/FFactoryV3.sol:30"
+            "contract": "FFactoryV2",
+            "src": "contracts/launchpadv2/FFactoryV2.sol:22"
           },
           {
             "label": "taxVault",
             "offset": 0,
             "slot": "3",
             "type": "t_address",
-            "contract": "FFactoryV3",
-            "src": "contracts/launchpadv2/FFactoryV3.sol:32"
+            "contract": "FFactoryV2",
+            "src": "contracts/launchpadv2/FFactoryV2.sol:24"
           },
           {
             "label": "buyTax",
             "offset": 0,
             "slot": "4",
             "type": "t_uint256",
-            "contract": "FFactoryV3",
-            "src": "contracts/launchpadv2/FFactoryV3.sol:33"
+            "contract": "FFactoryV2",
+            "src": "contracts/launchpadv2/FFactoryV2.sol:25"
           },
           {
             "label": "sellTax",
             "offset": 0,
             "slot": "5",
             "type": "t_uint256",
-            "contract": "FFactoryV3",
-            "src": "contracts/launchpadv2/FFactoryV3.sol:34"
+            "contract": "FFactoryV2",
+            "src": "contracts/launchpadv2/FFactoryV2.sol:26"
           },
           {
             "label": "antiSniperBuyTaxStartValue",
             "offset": 0,
             "slot": "6",
             "type": "t_uint256",
-            "contract": "FFactoryV3",
-            "src": "contracts/launchpadv2/FFactoryV3.sol:35"
+            "contract": "FFactoryV2",
+            "src": "contracts/launchpadv2/FFactoryV2.sol:27"
           },
           {
             "label": "antiSniperTaxVault",
             "offset": 0,
             "slot": "7",
             "type": "t_address",
-            "contract": "FFactoryV3",
-            "src": "contracts/launchpadv2/FFactoryV3.sol:36"
+            "contract": "FFactoryV2",
+            "src": "contracts/launchpadv2/FFactoryV2.sol:28"
           }
         ],
         "types": {
@@ -21423,7 +21423,7 @@
             "label": "reserveSupplyParams",
             "offset": 0,
             "slot": "0",
-            "type": "t_struct(ReserveSupplyParams)4858_storage",
+            "type": "t_struct(ReserveSupplyParams)3804_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:26"
           },
@@ -21431,7 +21431,7 @@
             "label": "scheduledLaunchParams",
             "offset": 0,
             "slot": "1",
-            "type": "t_struct(ScheduledLaunchParams)4877_storage",
+            "type": "t_struct(ScheduledLaunchParams)3823_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:41"
           },
@@ -21455,7 +21455,7 @@
             "label": "bondingCurveParams",
             "offset": 0,
             "slot": "6",
-            "type": "t_struct(BondingCurveParams)4892_storage",
+            "type": "t_struct(BondingCurveParams)3838_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:54"
           },
@@ -21463,7 +21463,7 @@
             "label": "deployParams",
             "offset": 0,
             "slot": "8",
-            "type": "t_struct(DeployParams)4979_storage",
+            "type": "t_struct(DeployParams)3925_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:109"
           },
@@ -21535,7 +21535,7 @@
             "label": "mapping(address => bool)",
             "numberOfBytes": "32"
           },
-          "t_struct(BondingCurveParams)4892_storage": {
+          "t_struct(BondingCurveParams)3838_storage": {
             "label": "struct BondingConfig.BondingCurveParams",
             "members": [
               {
@@ -21553,7 +21553,7 @@
             ],
             "numberOfBytes": "64"
           },
-          "t_struct(DeployParams)4979_storage": {
+          "t_struct(DeployParams)3925_storage": {
             "label": "struct BondingConfig.DeployParams",
             "members": [
               {
@@ -21583,7 +21583,7 @@
             ],
             "numberOfBytes": "96"
           },
-          "t_struct(ReserveSupplyParams)4858_storage": {
+          "t_struct(ReserveSupplyParams)3804_storage": {
             "label": "struct BondingConfig.ReserveSupplyParams",
             "members": [
               {
@@ -21607,7 +21607,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(ScheduledLaunchParams)4877_storage": {
+          "t_struct(ScheduledLaunchParams)3823_storage": {
             "label": "struct BondingConfig.ScheduledLaunchParams",
             "members": [
               {
@@ -24702,7 +24702,7 @@
             "label": "factory",
             "offset": 0,
             "slot": "0",
-            "type": "t_contract(IFFactoryV2Minimal)1973",
+            "type": "t_contract(IFFactoryV2Minimal)4446",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:95"
           },
@@ -24710,7 +24710,7 @@
             "label": "router",
             "offset": 0,
             "slot": "1",
-            "type": "t_contract(IFRouterV3Minimal)2035",
+            "type": "t_contract(IFRouterV3Minimal)4508",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:96"
           },
@@ -24718,7 +24718,7 @@
             "label": "agentFactory",
             "offset": 0,
             "slot": "2",
-            "type": "t_contract(IAgentFactoryV7Minimal)2100",
+            "type": "t_contract(IAgentFactoryV7Minimal)4573",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:97"
           },
@@ -24726,7 +24726,7 @@
             "label": "bondingConfig",
             "offset": 0,
             "slot": "3",
-            "type": "t_contract(BondingConfig)1935",
+            "type": "t_contract(BondingConfig)4408",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:98"
           },
@@ -24734,7 +24734,7 @@
             "label": "tokenInfo",
             "offset": 0,
             "slot": "4",
-            "type": "t_mapping(t_address,t_struct(Token)1432_storage)",
+            "type": "t_mapping(t_address,t_struct(Token)3905_storage)",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:100"
           },
@@ -24750,7 +24750,7 @@
             "label": "tokenLaunchParams",
             "offset": 0,
             "slot": "6",
-            "type": "t_mapping(t_address,t_struct(LaunchParams)1443_storage)",
+            "type": "t_mapping(t_address,t_struct(LaunchParams)3916_storage)",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:107"
           },
@@ -24772,7 +24772,7 @@
             "label": "bool",
             "numberOfBytes": "1"
           },
-          "t_struct(InitializableStorage)73_storage": {
+          "t_struct(InitializableStorage)266_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -24790,7 +24790,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(OwnableStorage)13_storage": {
+          "t_struct(OwnableStorage)206_storage": {
             "label": "struct OwnableUpgradeable.OwnableStorage",
             "members": [
               {
@@ -24802,7 +24802,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(ReentrancyGuardStorage)158_storage": {
+          "t_struct(ReentrancyGuardStorage)413_storage": {
             "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
             "members": [
               {
@@ -24830,27 +24830,27 @@
             "label": "uint8[]",
             "numberOfBytes": "32"
           },
-          "t_contract(BondingConfig)1935": {
+          "t_contract(BondingConfig)4408": {
             "label": "contract BondingConfig",
             "numberOfBytes": "20"
           },
-          "t_contract(IAgentFactoryV7Minimal)2100": {
+          "t_contract(IAgentFactoryV7Minimal)4573": {
             "label": "contract IAgentFactoryV7Minimal",
             "numberOfBytes": "20"
           },
-          "t_contract(IFFactoryV2Minimal)1973": {
+          "t_contract(IFFactoryV2Minimal)4446": {
             "label": "contract IFFactoryV2Minimal",
             "numberOfBytes": "20"
           },
-          "t_contract(IFRouterV3Minimal)2035": {
+          "t_contract(IFRouterV3Minimal)4508": {
             "label": "contract IFRouterV3Minimal",
             "numberOfBytes": "20"
           },
-          "t_mapping(t_address,t_struct(LaunchParams)1443_storage)": {
+          "t_mapping(t_address,t_struct(LaunchParams)3916_storage)": {
             "label": "mapping(address => struct BondingConfig.LaunchParams)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_address,t_struct(Token)1432_storage)": {
+          "t_mapping(t_address,t_struct(Token)3905_storage)": {
             "label": "mapping(address => struct BondingConfig.Token)",
             "numberOfBytes": "32"
           },
@@ -24862,7 +24862,7 @@
             "label": "string",
             "numberOfBytes": "32"
           },
-          "t_struct(Data)1393_storage": {
+          "t_struct(Data)3866_storage": {
             "label": "struct BondingConfig.Data",
             "members": [
               {
@@ -24940,7 +24940,7 @@
             ],
             "numberOfBytes": "384"
           },
-          "t_struct(LaunchParams)1443_storage": {
+          "t_struct(LaunchParams)3916_storage": {
             "label": "struct BondingConfig.LaunchParams",
             "members": [
               {
@@ -24976,7 +24976,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(Token)1432_storage": {
+          "t_struct(Token)3905_storage": {
             "label": "struct BondingConfig.Token",
             "members": [
               {
@@ -25005,7 +25005,7 @@
               },
               {
                 "label": "data",
-                "type": "t_struct(Data)1393_storage",
+                "type": "t_struct(Data)3866_storage",
                 "offset": 0,
                 "slot": "4"
               },
@@ -25151,7 +25151,7 @@
             "label": "factory",
             "offset": 0,
             "slot": "0",
-            "type": "t_contract(FFactoryV3)47938",
+            "type": "t_contract(FFactoryV3)6634",
             "contract": "FRouterV3",
             "src": "contracts/launchpadv2/FRouterV3.sol:47"
           },
@@ -25167,7 +25167,7 @@
             "label": "bondingV5",
             "offset": 0,
             "slot": "2",
-            "type": "t_contract(IBondingV5ForRouter)49865",
+            "type": "t_contract(IBondingV5ForRouter)7232",
             "contract": "FRouterV3",
             "src": "contracts/launchpadv2/FRouterV3.sol:51"
           },
@@ -25175,7 +25175,7 @@
             "label": "bondingConfig",
             "offset": 0,
             "slot": "3",
-            "type": "t_contract(IBondingConfigForRouter)49878",
+            "type": "t_contract(IBondingConfigForRouter)7245",
             "contract": "FRouterV3",
             "src": "contracts/launchpadv2/FRouterV3.sol:52"
           }
@@ -25213,7 +25213,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(InitializableStorage)1512_storage": {
+          "t_struct(InitializableStorage)266_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -25231,7 +25231,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(ReentrancyGuardStorage)2531_storage": {
+          "t_struct(ReentrancyGuardStorage)413_storage": {
             "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
             "members": [
               {
@@ -25269,15 +25269,15 @@
             "label": "uint64",
             "numberOfBytes": "8"
           },
-          "t_contract(FFactoryV3)47938": {
+          "t_contract(FFactoryV3)6634": {
             "label": "contract FFactoryV3",
             "numberOfBytes": "20"
           },
-          "t_contract(IBondingConfigForRouter)49878": {
+          "t_contract(IBondingConfigForRouter)7245": {
             "label": "contract IBondingConfigForRouter",
             "numberOfBytes": "20"
           },
-          "t_contract(IBondingV5ForRouter)49865": {
+          "t_contract(IBondingV5ForRouter)7232": {
             "label": "contract IBondingV5ForRouter",
             "numberOfBytes": "20"
           }
@@ -25334,7 +25334,7 @@
             "label": "factory",
             "offset": 0,
             "slot": "0",
-            "type": "t_contract(FFactoryV2)7674",
+            "type": "t_contract(FFactoryV2)8728",
             "contract": "FRouterV2",
             "src": "contracts/launchpadv2/FRouterV2.sol:38"
           },
@@ -25366,7 +25366,7 @@
             "label": "bondingV4",
             "offset": 0,
             "slot": "4",
-            "type": "t_contract(IBondingV4ForRouter)8273",
+            "type": "t_contract(IBondingV4ForRouter)9327",
             "contract": "FRouterV2",
             "src": "contracts/launchpadv2/FRouterV2.sol:58"
           },
@@ -25374,7 +25374,7 @@
             "label": "bondingV2",
             "offset": 0,
             "slot": "5",
-            "type": "t_contract(IBondingV2ForRouter)8265",
+            "type": "t_contract(IBondingV2ForRouter)9319",
             "contract": "FRouterV2",
             "src": "contracts/launchpadv2/FRouterV2.sol:59"
           }
@@ -25468,15 +25468,15 @@
             "label": "uint64",
             "numberOfBytes": "8"
           },
-          "t_contract(FFactoryV2)7674": {
+          "t_contract(FFactoryV2)8728": {
             "label": "contract FFactoryV2",
             "numberOfBytes": "20"
           },
-          "t_contract(IBondingV2ForRouter)8265": {
+          "t_contract(IBondingV2ForRouter)9319": {
             "label": "contract IBondingV2ForRouter",
             "numberOfBytes": "20"
           },
-          "t_contract(IBondingV4ForRouter)8273": {
+          "t_contract(IBondingV4ForRouter)9327": {
             "label": "contract IBondingV4ForRouter",
             "numberOfBytes": "20"
           }
@@ -26925,6 +26925,1315 @@
         "0x3EB211D1B64bDE1Af99BFAE95FE5063FD1678743",
         "0x5E357d0219E3a15674f18A5a197fB45E93568Ae9"
       ]
+    },
+    "853fa7fd6fb5ae3ecffa8dca79fbc58102a430bfa953cb0b43a4267ab1c55021": {
+      "address": "0xA9668B3205F67B497dE1F6350Cb29ae0Ca3899e8",
+      "txHash": "0x7a732b03da4ff2ea17854caf42ebe831cbcb2f3ccb85e69db9473f0f4fd91a3c",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(IFFactoryV2Minimal)8032",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:95"
+          },
+          {
+            "label": "router",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_contract(IFRouterV3Minimal)8094",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:96"
+          },
+          {
+            "label": "agentFactory",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IAgentFactoryV7Minimal)8159",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:97"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(BondingConfig)2988",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:98"
+          },
+          {
+            "label": "tokenInfo",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_struct(Token)2469_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:100"
+          },
+          {
+            "label": "tokenInfos",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:101"
+          },
+          {
+            "label": "tokenLaunchParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_address,t_struct(LaunchParams)2480_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:107"
+          },
+          {
+            "label": "tokenGradThreshold",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:110"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)151_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)296_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint8)dyn_storage": {
+            "label": "uint8[]",
+            "numberOfBytes": "32"
+          },
+          "t_contract(BondingConfig)2988": {
+            "label": "contract BondingConfig",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IAgentFactoryV7Minimal)8159": {
+            "label": "contract IAgentFactoryV7Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFFactoryV2Minimal)8032": {
+            "label": "contract IFFactoryV2Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFRouterV3Minimal)8094": {
+            "label": "contract IFRouterV3Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_struct(LaunchParams)2480_storage)": {
+            "label": "mapping(address => struct BondingConfig.LaunchParams)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Token)2469_storage)": {
+            "label": "mapping(address => struct BondingConfig.Token)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Data)2430_storage": {
+            "label": "struct BondingConfig.Data",
+            "members": [
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "ticker",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "supply",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "price",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "marketCap",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "liquidity",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "volume",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "volume24H",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "prevPrice",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "10"
+              },
+              {
+                "label": "lastUpdated",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "11"
+              }
+            ],
+            "numberOfBytes": "384"
+          },
+          "t_struct(LaunchParams)2480_storage": {
+            "label": "struct BondingConfig.LaunchParams",
+            "members": [
+              {
+                "label": "launchMode",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "airdropBips",
+                "type": "t_uint16",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "needAcf",
+                "type": "t_bool",
+                "offset": 3,
+                "slot": "0"
+              },
+              {
+                "label": "antiSniperTaxType",
+                "type": "t_uint8",
+                "offset": 4,
+                "slot": "0"
+              },
+              {
+                "label": "isProject60days",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Token)2469_storage": {
+            "label": "struct BondingConfig.Token",
+            "members": [
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "pair",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "agentToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "data",
+                "type": "t_struct(Data)2430_storage",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "description",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "16"
+              },
+              {
+                "label": "cores",
+                "type": "t_array(t_uint8)dyn_storage",
+                "offset": 0,
+                "slot": "17"
+              },
+              {
+                "label": "image",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "18"
+              },
+              {
+                "label": "twitter",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "19"
+              },
+              {
+                "label": "telegram",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "20"
+              },
+              {
+                "label": "youtube",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "21"
+              },
+              {
+                "label": "website",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "22"
+              },
+              {
+                "label": "trading",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "23"
+              },
+              {
+                "label": "tradingOnUniswap",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "23"
+              },
+              {
+                "label": "applicationId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "24"
+              },
+              {
+                "label": "initialPurchase",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "25"
+              },
+              {
+                "label": "virtualId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "26"
+              },
+              {
+                "label": "launchExecuted",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "27"
+              }
+            ],
+            "numberOfBytes": "896"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "e2355dd3c8296597f82bb1827f5d0b769dee9b1476e134381a18877b06f17601": {
+      "address": "0xC81844668fC9EC385B477848171A014a5aBa1b6a",
+      "txHash": "0xdbfe65bd43feb09a78f10a452464a016d7ab841d00de109c7bf78ac31ef5bbad",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "_pair",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_address))",
+            "contract": "FFactoryV2",
+            "src": "contracts/launchpadv2/FFactoryV2.sol:18"
+          },
+          {
+            "label": "pairs",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "FFactoryV2",
+            "src": "contracts/launchpadv2/FFactoryV2.sol:20"
+          },
+          {
+            "label": "router",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_address",
+            "contract": "FFactoryV2",
+            "src": "contracts/launchpadv2/FFactoryV2.sol:22"
+          },
+          {
+            "label": "taxVault",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_address",
+            "contract": "FFactoryV2",
+            "src": "contracts/launchpadv2/FFactoryV2.sol:24"
+          },
+          {
+            "label": "buyTax",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_uint256",
+            "contract": "FFactoryV2",
+            "src": "contracts/launchpadv2/FFactoryV2.sol:25"
+          },
+          {
+            "label": "sellTax",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_uint256",
+            "contract": "FFactoryV2",
+            "src": "contracts/launchpadv2/FFactoryV2.sol:26"
+          },
+          {
+            "label": "antiSniperBuyTaxStartValue",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_uint256",
+            "contract": "FFactoryV2",
+            "src": "contracts/launchpadv2/FFactoryV2.sol:27"
+          },
+          {
+            "label": "antiSniperTaxVault",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_address",
+            "contract": "FFactoryV2",
+            "src": "contracts/launchpadv2/FFactoryV2.sol:28"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)296_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_address))": {
+            "label": "mapping(address => mapping(address => address))",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "e1cbc298e1aecac556b007d94a69b6f668ddc4b93233206be906e9d50b05125d": {
+      "address": "0xa782902001F4E43405eE16A6Ac6ef909623AB1C4",
+      "txHash": "0xb179680f9262ced56f7fe66662f7638a91ce96a85b77f2e15614818b83df3cd7",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(FFactoryV2)10261",
+            "contract": "FRouterV2",
+            "src": "contracts/launchpadv2/FRouterV2.sol:39"
+          },
+          {
+            "label": "assetToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "FRouterV2",
+            "src": "contracts/launchpadv2/FRouterV2.sol:40"
+          },
+          {
+            "label": "taxManager",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_address",
+            "contract": "FRouterV2",
+            "src": "contracts/launchpadv2/FRouterV2.sol:41"
+          },
+          {
+            "label": "antiSniperTaxManager",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_address",
+            "contract": "FRouterV2",
+            "src": "contracts/launchpadv2/FRouterV2.sol:42"
+          },
+          {
+            "label": "bondingV4",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_contract(IBondingV4ForRouter)11226",
+            "contract": "FRouterV2",
+            "src": "contracts/launchpadv2/FRouterV2.sol:59"
+          },
+          {
+            "label": "bondingV2",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_contract(IBondingV2ForRouter)11218",
+            "contract": "FRouterV2",
+            "src": "contracts/launchpadv2/FRouterV2.sol:60"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)296_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(FFactoryV2)10261": {
+            "label": "contract FFactoryV2",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IBondingV2ForRouter)11218": {
+            "label": "contract IBondingV2ForRouter",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IBondingV4ForRouter)11226": {
+            "label": "contract IBondingV4ForRouter",
+            "numberOfBytes": "20"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "b80e1834a2354ea32b7450ade1893f41ca815cd217757b8f4bbe1a61b9a984ee": {
+      "address": "0x42Ea980E773FF5B18CC1c56f2F6Db8bF47d55e32",
+      "txHash": "0x60a3259f90a88f61dafe17dd4d07b9a82815edb726d63c8de6fc71e0db8a915f",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(FFactoryV3)10627",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:48"
+          },
+          {
+            "label": "assetToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:49"
+          },
+          {
+            "label": "bondingV5",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IBondingV5ForRouter)12559",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:52"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(IBondingConfigForRouter)12572",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:53"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)296_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(FFactoryV3)10627": {
+            "label": "contract FFactoryV3",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IBondingConfigForRouter)12572": {
+            "label": "contract IBondingConfigForRouter",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IBondingV5ForRouter)12559": {
+            "label": "contract IBondingV5ForRouter",
+            "numberOfBytes": "20"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "7a897a622182cf7744792957d6f73b7c019f92272e60f471ff6e1c2916925f2e": {
+      "address": "0xc1d5fa4A87aeFa2558f752ab01995c235994909b",
+      "txHash": "0x858c9d25f257cb0a13ff375f263cdcf65d6c3415d493563a58434b27f435b572",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "reserveSupplyParams",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_struct(ReserveSupplyParams)2368_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:26"
+          },
+          {
+            "label": "scheduledLaunchParams",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_struct(ScheduledLaunchParams)2387_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:41"
+          },
+          {
+            "label": "teamTokenReservedWallet",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:44"
+          },
+          {
+            "label": "isPrivilegedLauncher",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:47"
+          },
+          {
+            "label": "bondingCurveParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_struct(BondingCurveParams)2402_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:54"
+          },
+          {
+            "label": "deployParams",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_struct(DeployParams)2489_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:109"
+          },
+          {
+            "label": "initialSupply",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:112"
+          },
+          {
+            "label": "feeTo",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:113"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)151_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BondingCurveParams)2402_storage": {
+            "label": "struct BondingConfig.BondingCurveParams",
+            "members": [
+              {
+                "label": "fakeInitialVirtualLiq",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "targetRealVirtual",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(DeployParams)2489_storage": {
+            "label": "struct BondingConfig.DeployParams",
+            "members": [
+              {
+                "label": "tbaSalt",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tbaImplementation",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "daoVotingPeriod",
+                "type": "t_uint32",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "daoThreshold",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(ReserveSupplyParams)2368_storage": {
+            "label": "struct BondingConfig.ReserveSupplyParams",
+            "members": [
+              {
+                "label": "maxAirdropBips",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "maxTotalReservedBips",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              },
+              {
+                "label": "acfReservedBips",
+                "type": "t_uint16",
+                "offset": 4,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ScheduledLaunchParams)2387_storage": {
+            "label": "struct BondingConfig.ScheduledLaunchParams",
+            "members": [
+              {
+                "label": "startTimeDelay",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "normalLaunchFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "acfFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/contracts/launchpadv2/BondingConfig.sol
+++ b/contracts/launchpadv2/BondingConfig.sol
@@ -178,6 +178,9 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
     function setBondingCurveParams(
         BondingCurveParams memory params_
     ) external onlyOwner {
+        require(params_.fakeInitialVirtualLiq > 0, "fakeInitialVirtualLiq cannot be zero");
+        require(params_.targetRealVirtual > 0, "targetRealVirtual cannot be zero");
+        
         bondingCurveParams = params_;
         emit BondingCurveParamsUpdated(params_);
     }

--- a/contracts/launchpadv2/BondingV5.sol
+++ b/contracts/launchpadv2/BondingV5.sol
@@ -386,7 +386,7 @@ contract BondingV5 is
         return (token, pair, tokenInfo[token].virtualId, initialPurchase);
     }
 
-    function cancelLaunch(address tokenAddress_) public {
+    function cancelLaunch(address tokenAddress_) public nonReentrant() {
         BondingConfig.Token storage tokenRef = tokenInfo[tokenAddress_];
 
         // Validate that the token exists and was properly prelaunched

--- a/contracts/launchpadv2/FFactoryV2.sol
+++ b/contracts/launchpadv2/FFactoryV2.sol
@@ -113,6 +113,9 @@ contract FFactoryV2 is
         address antiSniperTaxVault_
     ) public onlyRole(ADMIN_ROLE) {
         require(newVault_ != address(0), "Zero addresses are not allowed.");
+        require(buyTax_ <= 99, "buyTax exceeds maximum");
+        require(sellTax_ <= 99, "sellTax exceeds maximum");
+        require(antiSniperBuyTaxStartValue_ <= 99, "antiSniper exceeds maximum");
 
         taxVault = newVault_;
         buyTax = buyTax_;

--- a/contracts/launchpadv2/FFactoryV2.sol
+++ b/contracts/launchpadv2/FFactoryV2.sol
@@ -24,7 +24,7 @@ contract FFactoryV2 is
     address public taxVault;
     uint256 public buyTax;
     uint256 public sellTax;
-    uint256 public antiSniperBuyTaxStartValue; // Starting tax value for anti-sniper (in basis points)
+    uint256 public antiSniperBuyTaxStartValue; // Anti-sniper starting tax (percentage, e.g. 99 = 99%)
     address public antiSniperTaxVault;
 
     event PairCreated(
@@ -117,6 +117,10 @@ contract FFactoryV2 is
         require(buyTax_ <= 99, "buyTax exceeds maximum");
         require(sellTax_ <= 99, "sellTax exceeds maximum");
         require(antiSniperBuyTaxStartValue_ <= 99, "antiSniper exceeds maximum");
+        require(
+            buyTax_ + antiSniperBuyTaxStartValue_ <= 100,
+            "Tax sum exceeds 100%"
+        );
 
         taxVault = newVault_;
         buyTax = buyTax_;

--- a/contracts/launchpadv2/FFactoryV2.sol
+++ b/contracts/launchpadv2/FFactoryV2.sol
@@ -113,6 +113,7 @@ contract FFactoryV2 is
         address antiSniperTaxVault_
     ) public onlyRole(ADMIN_ROLE) {
         require(newVault_ != address(0), "Zero addresses are not allowed.");
+        require(antiSniperTaxVault_ != address(0), "Zero address not allowed for antiSniperTaxVault");
         require(buyTax_ <= 99, "buyTax exceeds maximum");
         require(sellTax_ <= 99, "sellTax exceeds maximum");
         require(antiSniperBuyTaxStartValue_ <= 99, "antiSniper exceeds maximum");

--- a/contracts/launchpadv2/FFactoryV3.sol
+++ b/contracts/launchpadv2/FFactoryV3.sol
@@ -121,6 +121,9 @@ contract FFactoryV3 is
         address antiSniperTaxVault_
     ) public onlyRole(ADMIN_ROLE) {
         require(newVault_ != address(0), "Zero addresses are not allowed.");
+        require(buyTax_ <= 99, "buyTax exceeds maximum");
+        require(sellTax_ <= 99, "sellTax exceeds maximum");
+        require(antiSniperBuyTaxStartValue_ <= 99, "antiSniper exceeds maximum");
 
         taxVault = newVault_;
         buyTax = buyTax_;

--- a/contracts/launchpadv2/FFactoryV3.sol
+++ b/contracts/launchpadv2/FFactoryV3.sol
@@ -32,7 +32,7 @@ contract FFactoryV3 is
     address public taxVault;
     uint256 public buyTax;
     uint256 public sellTax;
-    uint256 public antiSniperBuyTaxStartValue;
+    uint256 public antiSniperBuyTaxStartValue; // Anti-sniper starting tax (percentage, e.g. 99 = 99%)
     address public antiSniperTaxVault;
 
     event PairCreated(
@@ -125,6 +125,7 @@ contract FFactoryV3 is
         require(buyTax_ <= 99, "buyTax exceeds maximum");
         require(sellTax_ <= 99, "sellTax exceeds maximum");
         require(antiSniperBuyTaxStartValue_ <= 99, "antiSniper exceeds maximum");
+        require(buyTax_ + antiSniperBuyTaxStartValue_ <= 100, "Tax sum exceeds 100%");
 
         taxVault = newVault_;
         buyTax = buyTax_;

--- a/contracts/launchpadv2/FFactoryV3.sol
+++ b/contracts/launchpadv2/FFactoryV3.sol
@@ -121,6 +121,7 @@ contract FFactoryV3 is
         address antiSniperTaxVault_
     ) public onlyRole(ADMIN_ROLE) {
         require(newVault_ != address(0), "Zero addresses are not allowed.");
+        require(antiSniperTaxVault_ != address(0), "Zero address not allowed for antiSniperTaxVault");
         require(buyTax_ <= 99, "buyTax exceeds maximum");
         require(sellTax_ <= 99, "sellTax exceeds maximum");
         require(antiSniperBuyTaxStartValue_ <= 99, "antiSniper exceeds maximum");

--- a/contracts/launchpadv2/FRouterV2.sol
+++ b/contracts/launchpadv2/FRouterV2.sol
@@ -476,7 +476,7 @@ contract FRouterV2 is
 
         // Call removeLpLiquidity through AgentFactoryV6
         // amountAMin and amountBMin set to 0 - this is a privileged drain operation
-        // No slippage protection needed since EXECUTOR_ROLE is trusted
+        // No slippage protection needed since BE_OPS_ROLE is trusted
         address agentFactory = bondingV2.agentFactory();
         IAgentFactoryV6(agentFactory).removeLpLiquidity(
             veToken,

--- a/contracts/launchpadv2/FRouterV2.sol
+++ b/contracts/launchpadv2/FRouterV2.sol
@@ -34,6 +34,7 @@ contract FRouterV2 is
 
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
+    bytes32 public constant BE_OPS_ROLE = keccak256("BE_OPS_ROLE");
 
     FFactoryV2 public factory;
     address public assetToken;
@@ -280,7 +281,7 @@ contract FRouterV2 is
     function resetTime(
         address tokenAddress,
         uint256 newStartTime
-    ) external onlyRole(EXECUTOR_ROLE) nonReentrant {
+    ) external onlyRole(BE_OPS_ROLE) nonReentrant {
         address pairAddress = factory.getPair(tokenAddress, assetToken);
 
         IFPairV2 pair = IFPairV2(pairAddress);
@@ -372,7 +373,7 @@ contract FRouterV2 is
 
     /**
      * @dev Drain all assets and tokens from a private pool (FPairV2)
-     * Only callable by EXECUTOR_ROLE and only for Project60days tokens
+     * Only callable by BE_OPS_ROLE and only for Project60days tokens
      * @param tokenAddress The address of the fun token (must be isProject60days)
      * @param recipient The address that will receive the drained assets and tokens
      * @return assetAmount Amount of asset tokens drained
@@ -381,7 +382,7 @@ contract FRouterV2 is
     function drainPrivatePool(
         address tokenAddress,
         address recipient
-    ) public onlyRole(EXECUTOR_ROLE) nonReentrant returns (uint256, uint256) {
+    ) public onlyRole(BE_OPS_ROLE) nonReentrant returns (uint256, uint256) {
         require(address(bondingV2) != address(0), "BondingV2 not set");
         require(tokenAddress != address(0), "Zero addresses are not allowed.");
         require(recipient != address(0), "Zero addresses are not allowed.");
@@ -425,7 +426,7 @@ contract FRouterV2 is
 
     /**
      * @dev Drain ALL liquidity from a UniswapV2 pool (for graduated tokens)
-     * Only callable by EXECUTOR_ROLE and only for Project60days tokens
+     * Only callable by BE_OPS_ROLE and only for Project60days tokens
      * @param agentToken The token address (same as agentToken in single token model, must be isProject60days)
      * @param veToken The veToken address (staked LP token) to drain from
      * @param recipient The address that will receive the drained liquidity
@@ -438,7 +439,7 @@ contract FRouterV2 is
         address veToken,
         address recipient,
         uint256 deadline
-    ) public onlyRole(EXECUTOR_ROLE) nonReentrant {
+    ) public onlyRole(BE_OPS_ROLE) nonReentrant {
         require(address(bondingV2) != address(0), "BondingV2 not set");
         require(agentToken != address(0), "Invalid agentToken");
         require(veToken != address(0), "Invalid veToken");

--- a/contracts/launchpadv2/FRouterV3.sol
+++ b/contracts/launchpadv2/FRouterV3.sol
@@ -43,6 +43,7 @@ contract FRouterV3 is
 
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
+    bytes32 public constant BE_OPS_ROLE = keccak256("BE_OPS_ROLE");
 
     FFactoryV3 public factory;
     address public assetToken;
@@ -264,7 +265,7 @@ contract FRouterV3 is
     function resetTime(
         address tokenAddress,
         uint256 newStartTime
-    ) external onlyRole(EXECUTOR_ROLE) nonReentrant {
+    ) external onlyRole(BE_OPS_ROLE) nonReentrant {
         address pairAddress = factory.getPair(tokenAddress, assetToken);
 
         IFPairV2 pair = IFPairV2(pairAddress);
@@ -367,7 +368,7 @@ contract FRouterV3 is
     function drainPrivatePool(
         address tokenAddress,
         address recipient
-    ) public onlyRole(EXECUTOR_ROLE) nonReentrant returns (uint256, uint256) {
+    ) public onlyRole(BE_OPS_ROLE) nonReentrant returns (uint256, uint256) {
         require(address(bondingV5) != address(0), "BondingV5 not set");
         require(tokenAddress != address(0), "Zero addresses are not allowed.");
         require(recipient != address(0), "Zero addresses are not allowed.");
@@ -411,7 +412,7 @@ contract FRouterV3 is
 
     /**
      * @dev Drain ALL liquidity from a UniswapV2 pool (for graduated tokens)
-     * Only callable by EXECUTOR_ROLE and only for Project60days tokens
+     * Only callable by BE_OPS_ROLE and only for Project60days tokens
      * @param agentToken The token address (same as agentToken in single token model, must be isProject60days)
      * @param veToken The veToken address (staked LP token) to drain from
      * @param recipient The address that will receive the drained liquidity
@@ -424,7 +425,7 @@ contract FRouterV3 is
         address veToken,
         address recipient,
         uint256 deadline
-    ) public onlyRole(EXECUTOR_ROLE) nonReentrant {
+    ) public onlyRole(BE_OPS_ROLE) nonReentrant {
         require(address(bondingV5) != address(0), "BondingV5 not set");
         require(agentToken != address(0), "Invalid agentToken");
         require(veToken != address(0), "Invalid veToken");
@@ -461,7 +462,7 @@ contract FRouterV3 is
 
         // Call removeLpLiquidity through AgentFactoryV7 (REMOVE_LIQUIDITY_ROLE on factory for this router)
         // amountAMin and amountBMin set to 0 - this is a privileged drain operation
-        // No slippage protection needed since EXECUTOR_ROLE is trusted
+        // No slippage protection needed since BE_OPS_ROLE is trusted
         address agentFactory = bondingV5.agentFactory();
         IAgentFactoryV7(agentFactory).removeLpLiquidity(
             veToken,

--- a/contracts/launchpadv2/FRouterV3.sol
+++ b/contracts/launchpadv2/FRouterV3.sol
@@ -359,7 +359,7 @@ contract FRouterV3 is
 
     /**
      * @dev Drain all assets and tokens from a private pool (FPairV2)
-     * Only callable by EXECUTOR_ROLE and only for Project60days tokens
+     * Only callable by BE_OPS_ROLE and only for Project60days tokens
      * @param tokenAddress The address of the fun token (must be isProject60days)
      * @param recipient The address that will receive the drained assets and tokens
      * @return assetAmount Amount of asset tokens drained

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -117,9 +117,18 @@ module.exports = {
     deployer: `privatekey://${process.env.PRIVATE_KEY}`,
   },
   etherscan: {
-    // Etherscan.io API keys work for v2 multi-chain verification (incl. Abscan-backed chains).
+    // Etherscan API V2 (single key, multichain via chainid): https://docs.etherscan.io/v2-migration
+    // Do not use legacy api.basescan.org/api — Hardhat-verify reports deprecated V1 / log fetch failures.
     apiKey: process.env.ETHERSCAN_API_KEY,
     customChains: [
+      {
+        network: "base",
+        chainId: 8453,
+        urls: {
+          apiURL: "https://api.etherscan.io/v2/api",
+          browserURL: "https://basescan.org/",
+        },
+      },
       {
         network: "base_sepolia",
         chainId: 84532,

--- a/scripts/launchpadv5/60daysDrainLiquidity.ts
+++ b/scripts/launchpadv5/60daysDrainLiquidity.ts
@@ -46,6 +46,10 @@ function walletFromPk(pk: string | undefined, label: string) {
   return new ethers.Wallet(t, ethers.provider);
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function main() {
   const mode = (process.env.DRAIN_LIQUIDITY_MODE || "univ2")
     .trim()
@@ -104,12 +108,37 @@ async function main() {
     );
   }
 
-  const execRole = await fRouterV3.EXECUTOR_ROLE();
-  if (!(await fRouterV3.hasRole(execRole, executorAddress))) {
+  const beOpsRole = await fRouterV3.BE_OPS_ROLE();
+  if (!(await fRouterV3.hasRole(beOpsRole, executorAddress))) {
     throw new Error(
-      `Executor ${executorAddress} lacks EXECUTOR_ROLE on FRouterV3`
+      `Executor ${executorAddress} lacks BE_OPS_ROLE on FRouterV3`
     );
   }
+
+  /**
+   * drainUniV2Pool is onlyRole(BE_OPS_ROLE) on FRouter, but it calls
+   * AgentFactoryV7.removeLpLiquidity — that uses msg.sender == FRouter, so the
+   * **router contract** must hold REMOVE_LIQUIDITY_ROLE on the factory (not your EOA).
+   */
+  const agentFactoryAddress = await bondingV5.agentFactory();
+  const agentFactory = await ethers.getContractAt(
+    "AgentFactoryV7",
+    agentFactoryAddress
+  );
+  const removeLiqRole = await agentFactory.REMOVE_LIQUIDITY_ROLE();
+  if (!(await agentFactory.hasRole(removeLiqRole, fRouterV3Address))) {
+    throw new Error(
+      `FRouterV3 ${fRouterV3Address} is missing REMOVE_LIQUIDITY_ROLE on AgentFactoryV7 ${agentFactoryAddress}. ` +
+        `BE_OPS_ROLE only allows your wallet to call drainUniV2Pool on the router; ` +
+        `the router then calls agentFactory.removeLpLiquidity (as msg.sender = FRouter). ` +
+        `Fix: admin on AgentFactoryV7 must grantRole(REMOVE_LIQUIDITY_ROLE, <this FRouterV3 address>).`
+    );
+  }
+  console.log(
+    "AgentFactory REMOVE_LIQUIDITY_ROLE on FRouterV3:",
+    fRouterV3Address,
+    "✅"
+  );
 
   const bal = await virtualToken.balanceOf(creatorAddress);
   if (mode === "univ2" && bal < GRAD_BUY_AMOUNT) {
@@ -192,9 +221,13 @@ async function main() {
   const veToken = await findVeTokenForAgentToken(agentNftV2, tokenAddress);
   console.log("veToken:", veToken);
 
-  const latest = await ethers.provider.getBlock("latest");
-  const deadline = BigInt(latest!.timestamp) + 3600n;
+  await sleep(10000); // wait for 10 seconds to drain
+
+  // `removeLiquidity` needs deadline > block.timestamp. Using wall clock avoids RPC
+  // "latest" block timestamp lag; ensure this machine's time is not behind the chain.
+  const deadline = BigInt(Math.floor(Date.now() / 1000)) + 3600n;
   console.log("\n--- 5) drainUniV2Pool → creator ---");
+  console.log("deadline (unix s):", deadline.toString());
   const txU = await fRouterV3.drainUniV2Pool(
     tokenAddress,
     veToken,

--- a/scripts/launchpadv5/testAgentTokenBurn.ts
+++ b/scripts/launchpadv5/testAgentTokenBurn.ts
@@ -1,0 +1,108 @@
+/**
+ * Smoke-test AgentToken `burn(uint256)` (e.g. AgentTokenV4): burn a fixed amount,
+ * then assert totalSupply and caller balance each decrease by that amount.
+ *
+ * Usage:
+ *   ENV_FILE=.env.launchpadv5_dev_arbitrum_sepolia npx hardhat run scripts/launchpadv5/testAgentTokenBurn.ts --network arbitrum_sepolia
+ *
+ * Configuration: edit CONFIG below (token address + human-readable burn amount).
+ * If AGENT_TOKEN_ADDRESS is empty, falls back to process.env.AGENT_TOKEN_ADDRESS.
+ */
+import { formatUnits, parseUnits } from "ethers";
+const hre = require("hardhat");
+const { ethers } = hre;
+
+// ============================================
+// Hardcode — edit here
+// ============================================
+const CONFIG = {
+  /** Set to "" to use AGENT_TOKEN_ADDRESS from env */
+  AGENT_TOKEN_ADDRESS: "0x41398E39188B425e6742e51dc11958C8CAb3D7eF" as string,
+  /** Human amount, e.g. "1" = 1 token in token decimals */
+  BURN_AMOUNT: "1",
+};
+
+const ERC20_BURN_ABI = [
+  "function burn(uint256 value) external",
+  "function balanceOf(address account) external view returns (uint256)",
+  "function totalSupply() external view returns (uint256)",
+  "function decimals() external view returns (uint8)",
+  "function symbol() external view returns (string)",
+] as const;
+
+function resolveTokenAddress(): string {
+  const fromConfig = (CONFIG.AGENT_TOKEN_ADDRESS || "").trim();
+  if (fromConfig) return ethers.getAddress(fromConfig);
+  const fromEnv = (process.env.AGENT_TOKEN_ADDRESS || "").trim();
+  if (!fromEnv) {
+    throw new Error(
+      "Set CONFIG.AGENT_TOKEN_ADDRESS or AGENT_TOKEN_ADDRESS in the env file."
+    );
+  }
+  return ethers.getAddress(fromEnv);
+}
+
+(async () => {
+  try {
+    const [signer] = await ethers.getSigners();
+    const deployer = await signer.getAddress();
+    const tokenAddr = resolveTokenAddress();
+
+    const token = new ethers.Contract(tokenAddr, ERC20_BURN_ABI, signer);
+    const decimals = Number(await token.decimals());
+    const symbol = await token.symbol().catch(() => "?");
+
+    const burnWei = parseUnits(CONFIG.BURN_AMOUNT, decimals);
+
+    console.log("\n=== testAgentTokenBurn ===");
+    console.log("Network:", hre.network.name);
+    console.log("Signer:", deployer);
+    console.log("Token:", tokenAddr, `(${symbol}, decimals=${decimals})`);
+    console.log("Burn amount:", CONFIG.BURN_AMOUNT, "→", burnWei.toString(), "wei");
+
+    const supplyBefore = BigInt(await token.totalSupply());
+    const balBefore = BigInt(await token.balanceOf(deployer));
+
+    if (balBefore < burnWei) {
+      throw new Error(
+        `Insufficient balance: have ${formatUnits(balBefore, decimals)}, need ${CONFIG.BURN_AMOUNT}`
+      );
+    }
+
+    const tx = await token.burn(burnWei);
+    console.log("burn tx:", tx.hash);
+    const receipt = await tx.wait();
+    if (!receipt || receipt.status !== 1) {
+      throw new Error("burn tx failed or no receipt");
+    }
+
+    const supplyAfter = BigInt(await token.totalSupply());
+    const balAfter = BigInt(await token.balanceOf(deployer));
+
+    const supplyDelta = supplyBefore - supplyAfter;
+    const balDelta = balBefore - balAfter;
+
+    console.log("\n--- Before ---");
+    console.log("totalSupply:", supplyBefore.toString(), `(${formatUnits(supplyBefore, decimals)})`);
+    console.log("balance:    ", balBefore.toString(), `(${formatUnits(balBefore, decimals)})`);
+
+    console.log("\n--- After ---");
+    console.log("totalSupply:", supplyAfter.toString(), `(${formatUnits(supplyAfter, decimals)})`);
+    console.log("balance:    ", balAfter.toString(), `(${formatUnits(balAfter, decimals)})`);
+
+    console.log("\n--- Deltas (expected = burn wei) ---");
+    console.log("totalSupply Δ:", supplyDelta.toString(), supplyDelta === burnWei ? "✅" : "❌");
+    console.log("balance Δ:    ", balDelta.toString(), balDelta === burnWei ? "✅" : "❌");
+
+    if (supplyDelta !== burnWei || balDelta !== burnWei) {
+      throw new Error(
+        `Assertion failed: expected supply and balance to each drop by ${burnWei.toString()}`
+      );
+    }
+
+    console.log("\n✅ burn() OK — totalSupply and balance both decreased by burn amount.");
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes on-chain access control (introducing `BE_OPS_ROLE` for drain/reset operations) and adds new parameter validation on tax/bonding-curve setters, which can block previously-valid admin actions if misconfigured.
> 
> **Overview**
> Adds stricter validation across launchpad contracts: `BondingConfig.setBondingCurveParams` now rejects zero bonding-curve values, and `FFactoryV2`/`FFactoryV3.setTaxParams` now enforce non-zero anti-sniper vaults, cap individual taxes at 99%, and prevent combined buy+anti-sniper tax exceeding 100%.
> 
> Hardens execution paths and permissions: `BondingV5.cancelLaunch` is now `nonReentrant`, and `FRouterV2`/`FRouterV3` introduce `BE_OPS_ROLE` and move `resetTime` plus liquidity drain functions (`drainPrivatePool`, `drainUniV2Pool`) from `EXECUTOR_ROLE` to this new role.
> 
> Operational updates include Hardhat verify config switching Base to Etherscan V2 endpoints, updates to the `60daysDrainLiquidity` script to use `BE_OPS_ROLE`, preflight-check router/factory roles, and use wall-clock deadlines, plus a new `testAgentTokenBurn.ts` smoke-test script; OpenZeppelin network files are updated with new deployment entries/layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45a284e217a5c0fe5dd44bfa731c562ff85f90f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->