### PR TITLE
feat: v2 partnerid changes

### DIFF
--- a/.openzeppelin/base-sepolia.json
+++ b/.openzeppelin/base-sepolia.json
@@ -56147,7 +56147,7 @@
             "label": "router",
             "offset": 0,
             "slot": "2",
-            "type": "t_contract(IRouter)13948",
+            "type": "t_contract(IRouter)4585",
             "contract": "AgentTaxV2",
             "src": "contracts/tax/AgentTaxV2.sol:50"
           },
@@ -56187,7 +56187,7 @@
             "label": "tokenRecipients",
             "offset": 0,
             "slot": "6",
-            "type": "t_mapping(t_address,t_struct(TaxRecipient)14241_storage)",
+            "type": "t_mapping(t_address,t_struct(TaxRecipient)4636_storage)",
             "contract": "AgentTaxV2",
             "src": "contracts/tax/AgentTaxV2.sol:56"
           },
@@ -56195,7 +56195,7 @@
             "label": "tokenTaxAmounts",
             "offset": 0,
             "slot": "7",
-            "type": "t_mapping(t_address,t_struct(TaxAmounts)14246_storage)",
+            "type": "t_mapping(t_address,t_struct(TaxAmounts)4641_storage)",
             "contract": "AgentTaxV2",
             "src": "contracts/tax/AgentTaxV2.sol:57"
           },
@@ -56203,7 +56203,7 @@
             "label": "bondingV5",
             "offset": 0,
             "slot": "8",
-            "type": "t_contract(IBondingV5ForTaxV2)14227",
+            "type": "t_contract(IBondingV5ForTaxV2)4622",
             "contract": "AgentTaxV2",
             "src": "contracts/tax/AgentTaxV2.sol:59"
           }
@@ -56281,23 +56281,23 @@
             "label": "uint64",
             "numberOfBytes": "8"
           },
-          "t_contract(IBondingV5ForTaxV2)14227": {
+          "t_contract(IBondingV5ForTaxV2)4622": {
             "label": "contract IBondingV5ForTaxV2",
             "numberOfBytes": "20"
           },
-          "t_contract(IRouter)13948": {
+          "t_contract(IRouter)4585": {
             "label": "contract IRouter",
             "numberOfBytes": "20"
           },
-          "t_mapping(t_address,t_struct(TaxAmounts)14246_storage)": {
+          "t_mapping(t_address,t_struct(TaxAmounts)4641_storage)": {
             "label": "mapping(address => struct AgentTaxV2.TaxAmounts)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_address,t_struct(TaxRecipient)14241_storage)": {
+          "t_mapping(t_address,t_struct(TaxRecipient)4636_storage)": {
             "label": "mapping(address => struct AgentTaxV2.TaxRecipient)",
             "numberOfBytes": "32"
           },
-          "t_struct(TaxAmounts)14246_storage": {
+          "t_struct(TaxAmounts)4641_storage": {
             "label": "struct AgentTaxV2.TaxAmounts",
             "members": [
               {
@@ -56315,7 +56315,7 @@
             ],
             "numberOfBytes": "64"
           },
-          "t_struct(TaxRecipient)14241_storage": {
+          "t_struct(TaxRecipient)4636_storage": {
             "label": "struct AgentTaxV2.TaxRecipient",
             "members": [
               {
@@ -57781,6 +57781,309 @@
         "0xEC5C72c6f4020D63b45c51808916aAfd85c3198F",
         "0x676dcaD5c94894c6B4De57eb750F847675C1ae53"
       ]
+    },
+    "c390bd02a2bca55cb7a2c3d3977153326b96326dfa8c7044582c7058cd659571": {
+      "address": "0x787605C9a336c7cd54Ea6991bd329137e9be0576",
+      "txHash": "0x9faa524c01c2764e6c66f6867ff68fcbd982e787f64e78f712864096728dc12f",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "assetToken",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:53"
+          },
+          {
+            "label": "taxToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:54"
+          },
+          {
+            "label": "router",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IRouter)1485",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:55"
+          },
+          {
+            "label": "treasury",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_address",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:56"
+          },
+          {
+            "label": "feeRate",
+            "offset": 20,
+            "slot": "3",
+            "type": "t_uint16",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:57"
+          },
+          {
+            "label": "minSwapThreshold",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_uint256",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:58"
+          },
+          {
+            "label": "maxSwapThreshold",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_uint256",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:59"
+          },
+          {
+            "label": "tokenRecipients",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_address,t_struct(TaxRecipient)1536_storage)",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:61"
+          },
+          {
+            "label": "tokenTaxAmounts",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_struct(TaxAmounts)1541_storage)",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:62"
+          },
+          {
+            "label": "bondingV5",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_contract(IBondingV5ForTaxV2)1522",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:64"
+          },
+          {
+            "label": "partnerRecipients",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_mapping(t_bytes32,t_address)",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:66"
+          },
+          {
+            "label": "tokenPartnerConfigs",
+            "offset": 0,
+            "slot": "10",
+            "type": "t_mapping(t_address,t_struct(TokenPartnerConfig)1546_storage)",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:67"
+          },
+          {
+            "label": "maxPartnerFeeRate",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_uint16",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:70"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)145_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(IBondingV5ForTaxV2)1522": {
+            "label": "contract IBondingV5ForTaxV2",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IRouter)1485": {
+            "label": "contract IRouter",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_struct(TaxAmounts)1541_storage)": {
+            "label": "mapping(address => struct AgentTaxV2.TaxAmounts)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(TaxRecipient)1536_storage)": {
+            "label": "mapping(address => struct AgentTaxV2.TaxRecipient)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(TokenPartnerConfig)1546_storage)": {
+            "label": "mapping(address => struct AgentTaxV2.TokenPartnerConfig)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_address)": {
+            "label": "mapping(bytes32 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(TaxAmounts)1541_storage": {
+            "label": "struct AgentTaxV2.TaxAmounts",
+            "members": [
+              {
+                "label": "amountCollected",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "amountSwapped",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(TaxRecipient)1536_storage": {
+            "label": "struct AgentTaxV2.TaxRecipient",
+            "members": [
+              {
+                "label": "tba",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(TokenPartnerConfig)1546_storage": {
+            "label": "struct AgentTaxV2.TokenPartnerConfig",
+            "members": [
+              {
+                "label": "partnerId",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "partnerFeeRate",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/base.json
+++ b/.openzeppelin/base.json
@@ -29425,6 +29425,309 @@
           ]
         }
       }
+    },
+    "c390bd02a2bca55cb7a2c3d3977153326b96326dfa8c7044582c7058cd659571": {
+      "address": "0xF6dEd65faaB429b2d5E13552D618a2E231f3D129",
+      "txHash": "0x4312bf53bf4bc4e74be23e6801a0b2fe451f8cb16fe9fafe34939ccb5a98939b",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "assetToken",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:53"
+          },
+          {
+            "label": "taxToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:54"
+          },
+          {
+            "label": "router",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IRouter)1485",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:55"
+          },
+          {
+            "label": "treasury",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_address",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:56"
+          },
+          {
+            "label": "feeRate",
+            "offset": 20,
+            "slot": "3",
+            "type": "t_uint16",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:57"
+          },
+          {
+            "label": "minSwapThreshold",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_uint256",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:58"
+          },
+          {
+            "label": "maxSwapThreshold",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_uint256",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:59"
+          },
+          {
+            "label": "tokenRecipients",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_address,t_struct(TaxRecipient)1536_storage)",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:61"
+          },
+          {
+            "label": "tokenTaxAmounts",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_struct(TaxAmounts)1541_storage)",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:62"
+          },
+          {
+            "label": "bondingV5",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_contract(IBondingV5ForTaxV2)1522",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:64"
+          },
+          {
+            "label": "partnerRecipients",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_mapping(t_bytes32,t_address)",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:66"
+          },
+          {
+            "label": "tokenPartnerConfigs",
+            "offset": 0,
+            "slot": "10",
+            "type": "t_mapping(t_address,t_struct(TokenPartnerConfig)1546_storage)",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:67"
+          },
+          {
+            "label": "maxPartnerFeeRate",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_uint16",
+            "contract": "AgentTaxV2",
+            "src": "contracts/tax/AgentTaxV2.sol:70"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)145_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(IBondingV5ForTaxV2)1522": {
+            "label": "contract IBondingV5ForTaxV2",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IRouter)1485": {
+            "label": "contract IRouter",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_struct(TaxAmounts)1541_storage)": {
+            "label": "mapping(address => struct AgentTaxV2.TaxAmounts)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(TaxRecipient)1536_storage)": {
+            "label": "mapping(address => struct AgentTaxV2.TaxRecipient)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(TokenPartnerConfig)1546_storage)": {
+            "label": "mapping(address => struct AgentTaxV2.TokenPartnerConfig)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_address)": {
+            "label": "mapping(bytes32 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(TaxAmounts)1541_storage": {
+            "label": "struct AgentTaxV2.TaxAmounts",
+            "members": [
+              {
+                "label": "amountCollected",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "amountSwapped",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(TaxRecipient)1536_storage": {
+            "label": "struct AgentTaxV2.TaxRecipient",
+            "members": [
+              {
+                "label": "tba",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(TokenPartnerConfig)1546_storage": {
+            "label": "struct AgentTaxV2.TokenPartnerConfig",
+            "members": [
+              {
+                "label": "partnerId",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "partnerFeeRate",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/contracts/tax/AgentTaxV2.sol
+++ b/contracts/tax/AgentTaxV2.sol
@@ -38,6 +38,11 @@ contract AgentTaxV2 is Initializable, AccessControlUpgradeable {
         uint256 amountSwapped;
     }
 
+    struct TokenPartnerConfig {
+        bytes32 partnerId;
+        uint16 partnerFeeRate;
+    }
+
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant REGISTER_ROLE = keccak256("REGISTER_ROLE");
     bytes32 public constant SWAP_ROLE = keccak256("SWAP_ROLE");
@@ -57,6 +62,9 @@ contract AgentTaxV2 is Initializable, AccessControlUpgradeable {
     mapping(address tokenAddress => TaxAmounts) public tokenTaxAmounts;
 
     IBondingV5ForTaxV2 public bondingV5;
+
+    mapping(bytes32 partnerId => address recipient) public partnerRecipients;
+    mapping(address tokenAddress => TokenPartnerConfig) public tokenPartnerConfigs;
 
     event TokenRegistered(address indexed tokenAddress, address indexed creator, address tba);
     event TaxDeposited(address indexed tokenAddress, uint256 amount);
@@ -78,6 +86,23 @@ contract AgentTaxV2 is Initializable, AccessControlUpgradeable {
         uint256 newMaxThreshold
     );
     event TreasuryUpdated(address oldTreasury, address newTreasury);
+    event PartnerRecipientUpdated(
+        bytes32 indexed partnerId,
+        address oldRecipient,
+        address newRecipient
+    );
+    event TokenPartnerConfigUpdated(
+        address indexed tokenAddress,
+        bytes32 indexed partnerId,
+        uint16 partnerFeeRate
+    );
+    event PartnerFeeDistributed(
+        address indexed tokenAddress,
+        bytes32 indexed partnerId,
+        address indexed recipient,
+        uint256 amount
+    );
+    event FeeSplitUpdated(uint16 oldProtocolFeeRate, uint16 newProtocolFeeRate);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -307,7 +332,21 @@ contract AgentTaxV2 is Initializable, AccessControlUpgradeable {
             emit SwapExecuted(tokenAddress, amountToSwap, assetReceived);
 
             uint256 protocolFee = (assetReceived * feeRate) / DENOM;
-            uint256 creatorFee = assetReceived - protocolFee;
+
+            TokenPartnerConfig memory partnerConfig = tokenPartnerConfigs[tokenAddress];
+            uint256 partnerFee = (assetReceived * partnerConfig.partnerFeeRate) / DENOM;
+            uint256 creatorFee = assetReceived - protocolFee - partnerFee;
+
+            if (partnerFee > 0) {
+                address partnerRecipient = partnerRecipients[partnerConfig.partnerId];
+                IERC20(assetToken).safeTransfer(partnerRecipient, partnerFee);
+                emit PartnerFeeDistributed(
+                    tokenAddress,
+                    partnerConfig.partnerId,
+                    partnerRecipient,
+                    partnerFee
+                );
+            }
 
             if (creatorFee > 0) {
                 IERC20(assetToken).safeTransfer(recipient.creator, creatorFee);
@@ -345,6 +384,16 @@ contract AgentTaxV2 is Initializable, AccessControlUpgradeable {
         return (amounts.amountCollected, amounts.amountSwapped);
     }
 
+    /**
+     * @notice Get partner fee configuration for an agent token
+     */
+    function getTokenPartnerConfig(
+        address tokenAddress
+    ) external view returns (bytes32 partnerId, uint16 partnerFeeRate) {
+        TokenPartnerConfig memory config = tokenPartnerConfigs[tokenAddress];
+        return (config.partnerId, config.partnerFeeRate);
+    }
+
     // ============ Creator Functions ============
 
     /**
@@ -372,6 +421,73 @@ contract AgentTaxV2 is Initializable, AccessControlUpgradeable {
     }
 
     // ============ Admin Functions ============
+
+    /**
+     * @notice Set the receiving address for a partner / referrer integration
+     * @param partnerId Unique partner identifier
+     * @param recipient Address that receives partner fee shares
+     */
+    function setPartnerRecipient(
+        bytes32 partnerId,
+        address recipient
+    ) external onlyRole(ADMIN_ROLE) {
+        require(partnerId != bytes32(0), "Invalid partner ID");
+        require(recipient != address(0), "Invalid recipient");
+
+        address oldRecipient = partnerRecipients[partnerId];
+        partnerRecipients[partnerId] = recipient;
+
+        emit PartnerRecipientUpdated(partnerId, oldRecipient, recipient);
+    }
+
+    /**
+     * @notice Configure partner fee split for an agent token
+     * @dev Partner fee is deducted from the total swapped asset amount alongside the
+     *      protocol fee. Remaining amount goes to the token creator.
+     *      `feeRate + partnerFeeRate` must not exceed DENOM (100%).
+     * @param tokenAddress The agent token address
+     * @param partnerId Partner identifier (must have recipient configured if rate > 0)
+     * @param partnerFeeRate Partner share in basis points (out of 10000)
+     */
+    function setTokenPartnerConfig(
+        address tokenAddress,
+        bytes32 partnerId,
+        uint16 partnerFeeRate
+    ) external onlyRole(ADMIN_ROLE) {
+        require(tokenAddress != address(0), "Invalid token address");
+        require(feeRate + partnerFeeRate <= DENOM, "Fee split exceeds 100%");
+
+        if (partnerFeeRate > 0) {
+            require(partnerId != bytes32(0), "Partner ID required");
+            require(
+                partnerRecipients[partnerId] != address(0),
+                "Partner recipient not set"
+            );
+        }
+
+        tokenPartnerConfigs[tokenAddress] = TokenPartnerConfig({
+            partnerId: partnerId,
+            partnerFeeRate: partnerFeeRate
+        });
+
+        emit TokenPartnerConfigUpdated(tokenAddress, partnerId, partnerFeeRate);
+    }
+
+    /**
+     * @notice Update the global protocol (treasury) fee rate
+     * @dev Per-token partner fees are configured via setTokenPartnerConfig().
+     *      After updating, ensure `feeRate + partnerFeeRate <= DENOM` for all tokens
+     *      with an active partner split.
+     * @param protocolFeeRate_ Protocol share in basis points (out of 10000)
+     */
+    function updateFeeSplit(uint16 protocolFeeRate_) external onlyRole(ADMIN_ROLE) {
+        require(protocolFeeRate_ <= DENOM, "Fee rate too high");
+
+        uint16 oldFeeRate = feeRate;
+        feeRate = protocolFeeRate_;
+
+        emit FeeSplitUpdated(oldFeeRate, protocolFeeRate_);
+    }
 
     /**
      * @notice Set BondingV5 contract address

--- a/contracts/tax/AgentTaxV2.sol
+++ b/contracts/tax/AgentTaxV2.sol
@@ -65,6 +65,9 @@ contract AgentTaxV2 is Initializable, AccessControlUpgradeable {
 
     mapping(bytes32 partnerId => address recipient) public partnerRecipients;
     mapping(address tokenAddress => TokenPartnerConfig) public tokenPartnerConfigs;
+    /// @dev Upper bound of any configured per-token partner fee; used to guard `updateSwapParams`.
+    ///      Not decreased when individual tokens lower their rate (conservative).
+    uint16 public maxPartnerFeeRate;
 
     event TokenRegistered(address indexed tokenAddress, address indexed creator, address tba);
     event TaxDeposited(address indexed tokenAddress, uint256 amount);
@@ -335,7 +338,19 @@ contract AgentTaxV2 is Initializable, AccessControlUpgradeable {
 
             TokenPartnerConfig memory partnerConfig = tokenPartnerConfigs[tokenAddress];
             uint256 partnerFee = (assetReceived * partnerConfig.partnerFeeRate) / DENOM;
-            uint256 creatorFee = assetReceived - protocolFee - partnerFee;
+
+            // Cap fees if protocol + partner rates exceed 100% (e.g. after feeRate was raised
+            // without re-validating partner configs). Prevents underflow from bricking swaps.
+            uint256 remaining = assetReceived;
+            if (protocolFee > remaining) {
+                protocolFee = remaining;
+            }
+            remaining -= protocolFee;
+            if (partnerFee > remaining) {
+                partnerFee = remaining;
+            }
+            remaining -= partnerFee;
+            uint256 creatorFee = remaining;
 
             if (partnerFee > 0) {
                 address partnerRecipient = partnerRecipients[partnerConfig.partnerId];
@@ -445,6 +460,8 @@ contract AgentTaxV2 is Initializable, AccessControlUpgradeable {
      * @dev Partner fee is deducted from the total swapped asset amount alongside the
      *      protocol fee. Remaining amount goes to the token creator.
      *      `feeRate + partnerFeeRate` must not exceed DENOM (100%).
+     *      First configuration per token: EXECUTOR_ROLE or ADMIN_ROLE.
+     *      Subsequent updates: ADMIN_ROLE only.
      * @param tokenAddress The agent token address
      * @param partnerId Partner identifier (must have recipient configured if rate > 0)
      * @param partnerFeeRate Partner share in basis points (out of 10000)
@@ -453,7 +470,21 @@ contract AgentTaxV2 is Initializable, AccessControlUpgradeable {
         address tokenAddress,
         bytes32 partnerId,
         uint16 partnerFeeRate
-    ) external onlyRole(ADMIN_ROLE) {
+    ) external {
+        address sender = _msgSender();
+        TokenPartnerConfig memory existing = tokenPartnerConfigs[tokenAddress];
+        bool isUnset =
+            existing.partnerId == bytes32(0) && existing.partnerFeeRate == 0;
+
+        if (isUnset) {
+            require(
+                hasRole(EXECUTOR_ROLE, sender) || hasRole(ADMIN_ROLE, sender),
+                "Only executor or admin can set partner config"
+            );
+        } else {
+            require(hasRole(ADMIN_ROLE, sender), "Only admin can update partner config");
+        }
+
         require(tokenAddress != address(0), "Invalid token address");
         require(feeRate + partnerFeeRate <= DENOM, "Fee split exceeds 100%");
 
@@ -470,23 +501,11 @@ contract AgentTaxV2 is Initializable, AccessControlUpgradeable {
             partnerFeeRate: partnerFeeRate
         });
 
+        if (partnerFeeRate > maxPartnerFeeRate) {
+            maxPartnerFeeRate = partnerFeeRate;
+        }
+
         emit TokenPartnerConfigUpdated(tokenAddress, partnerId, partnerFeeRate);
-    }
-
-    /**
-     * @notice Update the global protocol (treasury) fee rate
-     * @dev Per-token partner fees are configured via setTokenPartnerConfig().
-     *      After updating, ensure `feeRate + partnerFeeRate <= DENOM` for all tokens
-     *      with an active partner split.
-     * @param protocolFeeRate_ Protocol share in basis points (out of 10000)
-     */
-    function updateFeeSplit(uint16 protocolFeeRate_) external onlyRole(ADMIN_ROLE) {
-        require(protocolFeeRate_ <= DENOM, "Fee rate too high");
-
-        uint16 oldFeeRate = feeRate;
-        feeRate = protocolFeeRate_;
-
-        emit FeeSplitUpdated(oldFeeRate, protocolFeeRate_);
     }
 
     /**
@@ -507,6 +526,10 @@ contract AgentTaxV2 is Initializable, AccessControlUpgradeable {
         uint16 feeRate_
     ) external onlyRole(ADMIN_ROLE) {
         require(feeRate_ <= DENOM, "Fee rate too high");
+        require(
+            feeRate_ + maxPartnerFeeRate <= DENOM,
+            "Fee split exceeds 100%"
+        );
 
         address oldRouter = address(router);
         address oldAsset = assetToken;

--- a/contracts/tax/AgentTaxV2.sol
+++ b/contracts/tax/AgentTaxV2.sol
@@ -354,6 +354,10 @@ contract AgentTaxV2 is Initializable, AccessControlUpgradeable {
 
             if (partnerFee > 0) {
                 address partnerRecipient = partnerRecipients[partnerConfig.partnerId];
+                require(
+                    partnerRecipient != address(0),
+                    "Partner recipient not set"
+                );
                 IERC20(assetToken).safeTransfer(partnerRecipient, partnerFee);
                 emit PartnerFeeDistributed(
                     tokenAddress,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes on-chain fund distribution after tax swaps; misconfiguration or a zero partner recipient could misroute asset token payouts.
> 
> **Overview**
> **AgentTaxV2** now supports **partner / referrer fee splits** on tax swaps. Admins map a `bytes32` **partnerId** to a payout address and, per agent token, set **partnerId** plus **partnerFeeRate** (basis points). After a successful swap, post-swap asset is split among **protocol** (`feeRate`), **partner**, and **creator** (remainder), with transfers and **`PartnerFeeDistributed`** events.
> 
> New admin entry points: **`setPartnerRecipient`**, **`setTokenPartnerConfig`** (requires recipient when rate &gt; 0; enforces `feeRate + partnerFeeRate ≤ 10000`), and **`updateFeeSplit`** for the global protocol rate. A view **`getTokenPartnerConfig`** exposes per-token partner settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57c9b167a0954900241efdb21e927f689a452fb4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->