### PR TITLE
feat: increase initial liq and adjust fdv dropoff at migration

### DIFF
--- a/.openzeppelin/base-sepolia.json
+++ b/.openzeppelin/base-sepolia.json
@@ -838,6 +838,11 @@
     {
       "address": "0x2eB4313e3047845FD07315A51003F1f440780cdD",
       "kind": "transparent"
+    },
+    {
+      "address": "0x9504c78bBAE95D63c0E87f576824Ea899D7e88cc",
+      "txHash": "0xd3fc4b2d93cb3998ba26d21647497bd85bbcaccd763694572fdb3a5352f2fbff",
+      "kind": "transparent"
     }
   ],
   "impls": {
@@ -58060,6 +58065,778 @@
               "label": "_roles",
               "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
               "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "096ac000042631ba2f46b625a207f7b6d48e1d401606ca0a1404339c91d6d0e7": {
+      "address": "0xC17df2b8f9FC3E8903B1813FD7D328EF13080163",
+      "txHash": "0x6cccd23491d555fecd45bce6ed54f95f1c7fbc8e57faa4dcc284f50d87a66dc7",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "reserveSupplyParams",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_struct(ReserveSupplyParams)1331_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:26"
+          },
+          {
+            "label": "scheduledLaunchParams",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_struct(ScheduledLaunchParams)1350_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:41"
+          },
+          {
+            "label": "teamTokenReservedWallet",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:44"
+          },
+          {
+            "label": "isPrivilegedLauncher",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:47"
+          },
+          {
+            "label": "bondingCurveParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_struct(BondingCurveParams)1365_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:54"
+          },
+          {
+            "label": "deployParams",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_struct(DeployParams)1452_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:109"
+          },
+          {
+            "label": "initialSupply",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:112"
+          },
+          {
+            "label": "feeTo",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:113"
+          },
+          {
+            "label": "acfFakeInitialVirtualLiq",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:118"
+          },
+          {
+            "label": "graduationExcessBurnWallet",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:121"
+          },
+          {
+            "label": "legacyInitialVirtualLiq",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:124"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BondingCurveParams)1365_storage": {
+            "label": "struct BondingConfig.BondingCurveParams",
+            "members": [
+              {
+                "label": "fakeInitialVirtualLiq",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "targetRealVirtual",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(DeployParams)1452_storage": {
+            "label": "struct BondingConfig.DeployParams",
+            "members": [
+              {
+                "label": "tbaSalt",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tbaImplementation",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "daoVotingPeriod",
+                "type": "t_uint32",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "daoThreshold",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(ReserveSupplyParams)1331_storage": {
+            "label": "struct BondingConfig.ReserveSupplyParams",
+            "members": [
+              {
+                "label": "maxAirdropBips",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "maxTotalReservedBips",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              },
+              {
+                "label": "acfReservedBips",
+                "type": "t_uint16",
+                "offset": 4,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ScheduledLaunchParams)1350_storage": {
+            "label": "struct BondingConfig.ScheduledLaunchParams",
+            "members": [
+              {
+                "label": "startTimeDelay",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "normalLaunchFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "acfFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "2b19a094fdd2a6e01984af3ba5ea4cbf3722936e7c48d0a49549c5167f3e22ff": {
+      "address": "0xDB53a2B1dC6152d950EF86318A2DfB5eeD263364",
+      "txHash": "0x407f9e14f78409a179aa3f5264e5dc1413503b977581afe43c13110a64e33f5f",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(IFFactoryV2Minimal)2110",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:95"
+          },
+          {
+            "label": "router",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_contract(IFRouterV3Minimal)2172",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:96"
+          },
+          {
+            "label": "agentFactory",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IAgentFactoryV7Minimal)2237",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:97"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(BondingConfig)2072",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:98"
+          },
+          {
+            "label": "tokenInfo",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_struct(Token)1432_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:100"
+          },
+          {
+            "label": "tokenInfos",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:101"
+          },
+          {
+            "label": "tokenLaunchParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_address,t_struct(LaunchParams)1443_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:107"
+          },
+          {
+            "label": "tokenGradThreshold",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:110"
+          },
+          {
+            "label": "isFeeDelegation",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:112"
+          },
+          {
+            "label": "tokenPreLaunchExtParams",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_mapping(t_address,t_bytes_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:115"
+          },
+          {
+            "label": "tokenFakeInitialVirtualLiq",
+            "offset": 0,
+            "slot": "10",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:120"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)158_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint8)dyn_storage": {
+            "label": "uint8[]",
+            "numberOfBytes": "32"
+          },
+          "t_bytes_storage": {
+            "label": "bytes",
+            "numberOfBytes": "32"
+          },
+          "t_contract(BondingConfig)2072": {
+            "label": "contract BondingConfig",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IAgentFactoryV7Minimal)2237": {
+            "label": "contract IAgentFactoryV7Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFFactoryV2Minimal)2110": {
+            "label": "contract IFFactoryV2Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFRouterV3Minimal)2172": {
+            "label": "contract IFRouterV3Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bytes_storage)": {
+            "label": "mapping(address => bytes)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(LaunchParams)1443_storage)": {
+            "label": "mapping(address => struct BondingConfig.LaunchParams)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Token)1432_storage)": {
+            "label": "mapping(address => struct BondingConfig.Token)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Data)1393_storage": {
+            "label": "struct BondingConfig.Data",
+            "members": [
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "ticker",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "supply",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "price",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "marketCap",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "liquidity",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "volume",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "volume24H",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "prevPrice",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "10"
+              },
+              {
+                "label": "lastUpdated",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "11"
+              }
+            ],
+            "numberOfBytes": "384"
+          },
+          "t_struct(LaunchParams)1443_storage": {
+            "label": "struct BondingConfig.LaunchParams",
+            "members": [
+              {
+                "label": "launchMode",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "airdropBips",
+                "type": "t_uint16",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "needAcf",
+                "type": "t_bool",
+                "offset": 3,
+                "slot": "0"
+              },
+              {
+                "label": "antiSniperTaxType",
+                "type": "t_uint8",
+                "offset": 4,
+                "slot": "0"
+              },
+              {
+                "label": "isProject60days",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Token)1432_storage": {
+            "label": "struct BondingConfig.Token",
+            "members": [
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "pair",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "agentToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "data",
+                "type": "t_struct(Data)1393_storage",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "description",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "16"
+              },
+              {
+                "label": "cores",
+                "type": "t_array(t_uint8)dyn_storage",
+                "offset": 0,
+                "slot": "17"
+              },
+              {
+                "label": "image",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "18"
+              },
+              {
+                "label": "twitter",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "19"
+              },
+              {
+                "label": "telegram",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "20"
+              },
+              {
+                "label": "youtube",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "21"
+              },
+              {
+                "label": "website",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "22"
+              },
+              {
+                "label": "trading",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "23"
+              },
+              {
+                "label": "tradingOnUniswap",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "23"
+              },
+              {
+                "label": "applicationId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "24"
+              },
+              {
+                "label": "initialPurchase",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "25"
+              },
+              {
+                "label": "virtualId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "26"
+              },
+              {
+                "label": "launchExecuted",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "27"
+              }
+            ],
+            "numberOfBytes": "896"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
               "offset": 0,
               "slot": "0"
             }

--- a/.openzeppelin/base.json
+++ b/.openzeppelin/base.json
@@ -27982,7 +27982,7 @@
             "label": "reserveSupplyParams",
             "offset": 0,
             "slot": "0",
-            "type": "t_struct(ReserveSupplyParams)2368_storage",
+            "type": "t_struct(ReserveSupplyParams)1331_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:26"
           },
@@ -27990,7 +27990,7 @@
             "label": "scheduledLaunchParams",
             "offset": 0,
             "slot": "1",
-            "type": "t_struct(ScheduledLaunchParams)2387_storage",
+            "type": "t_struct(ScheduledLaunchParams)1350_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:41"
           },
@@ -28014,7 +28014,7 @@
             "label": "bondingCurveParams",
             "offset": 0,
             "slot": "6",
-            "type": "t_struct(BondingCurveParams)2402_storage",
+            "type": "t_struct(BondingCurveParams)1365_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:54"
           },
@@ -28022,7 +28022,7 @@
             "label": "deployParams",
             "offset": 0,
             "slot": "8",
-            "type": "t_struct(DeployParams)2489_storage",
+            "type": "t_struct(DeployParams)1452_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:109"
           },
@@ -28052,7 +28052,7 @@
             "label": "bool",
             "numberOfBytes": "1"
           },
-          "t_struct(InitializableStorage)211_storage": {
+          "t_struct(InitializableStorage)73_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -28070,7 +28070,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(OwnableStorage)151_storage": {
+          "t_struct(OwnableStorage)13_storage": {
             "label": "struct OwnableUpgradeable.OwnableStorage",
             "members": [
               {
@@ -28094,7 +28094,7 @@
             "label": "mapping(address => bool)",
             "numberOfBytes": "32"
           },
-          "t_struct(BondingCurveParams)2402_storage": {
+          "t_struct(BondingCurveParams)1365_storage": {
             "label": "struct BondingConfig.BondingCurveParams",
             "members": [
               {
@@ -28112,7 +28112,7 @@
             ],
             "numberOfBytes": "64"
           },
-          "t_struct(DeployParams)2489_storage": {
+          "t_struct(DeployParams)1452_storage": {
             "label": "struct BondingConfig.DeployParams",
             "members": [
               {
@@ -28142,7 +28142,7 @@
             ],
             "numberOfBytes": "96"
           },
-          "t_struct(ReserveSupplyParams)2368_storage": {
+          "t_struct(ReserveSupplyParams)1331_storage": {
             "label": "struct BondingConfig.ReserveSupplyParams",
             "members": [
               {
@@ -28166,7 +28166,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(ScheduledLaunchParams)2387_storage": {
+          "t_struct(ScheduledLaunchParams)1350_storage": {
             "label": "struct BondingConfig.ScheduledLaunchParams",
             "members": [
               {
@@ -29704,6 +29704,778 @@
               "label": "_roles",
               "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
               "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "096ac000042631ba2f46b625a207f7b6d48e1d401606ca0a1404339c91d6d0e7": {
+      "address": "0x673C27a089e4eF3533c15A7cF0CA152886a55527",
+      "txHash": "0x7bc886f2c3673d8747d3b98c91c71af4099f5c4aa08071be5e3370e6cc043f84",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "reserveSupplyParams",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_struct(ReserveSupplyParams)1331_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:26"
+          },
+          {
+            "label": "scheduledLaunchParams",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_struct(ScheduledLaunchParams)1350_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:41"
+          },
+          {
+            "label": "teamTokenReservedWallet",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:44"
+          },
+          {
+            "label": "isPrivilegedLauncher",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:47"
+          },
+          {
+            "label": "bondingCurveParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_struct(BondingCurveParams)1365_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:54"
+          },
+          {
+            "label": "deployParams",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_struct(DeployParams)1452_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:109"
+          },
+          {
+            "label": "initialSupply",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:112"
+          },
+          {
+            "label": "feeTo",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:113"
+          },
+          {
+            "label": "acfFakeInitialVirtualLiq",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:118"
+          },
+          {
+            "label": "graduationExcessBurnWallet",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:121"
+          },
+          {
+            "label": "legacyInitialVirtualLiq",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:124"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BondingCurveParams)1365_storage": {
+            "label": "struct BondingConfig.BondingCurveParams",
+            "members": [
+              {
+                "label": "fakeInitialVirtualLiq",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "targetRealVirtual",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(DeployParams)1452_storage": {
+            "label": "struct BondingConfig.DeployParams",
+            "members": [
+              {
+                "label": "tbaSalt",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tbaImplementation",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "daoVotingPeriod",
+                "type": "t_uint32",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "daoThreshold",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(ReserveSupplyParams)1331_storage": {
+            "label": "struct BondingConfig.ReserveSupplyParams",
+            "members": [
+              {
+                "label": "maxAirdropBips",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "maxTotalReservedBips",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              },
+              {
+                "label": "acfReservedBips",
+                "type": "t_uint16",
+                "offset": 4,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ScheduledLaunchParams)1350_storage": {
+            "label": "struct BondingConfig.ScheduledLaunchParams",
+            "members": [
+              {
+                "label": "startTimeDelay",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "normalLaunchFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "acfFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "2b19a094fdd2a6e01984af3ba5ea4cbf3722936e7c48d0a49549c5167f3e22ff": {
+      "address": "0x3f6EbDA74003a8efc65714688885C374B66EF4eC",
+      "txHash": "0x5359cecf1185d9374a096335ab107c212621cd121785990dff0e681cb0a4451c",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(IFFactoryV2Minimal)2110",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:95"
+          },
+          {
+            "label": "router",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_contract(IFRouterV3Minimal)2172",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:96"
+          },
+          {
+            "label": "agentFactory",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IAgentFactoryV7Minimal)2237",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:97"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(BondingConfig)2072",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:98"
+          },
+          {
+            "label": "tokenInfo",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_struct(Token)1432_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:100"
+          },
+          {
+            "label": "tokenInfos",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:101"
+          },
+          {
+            "label": "tokenLaunchParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_address,t_struct(LaunchParams)1443_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:107"
+          },
+          {
+            "label": "tokenGradThreshold",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:110"
+          },
+          {
+            "label": "isFeeDelegation",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:112"
+          },
+          {
+            "label": "tokenPreLaunchExtParams",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_mapping(t_address,t_bytes_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:115"
+          },
+          {
+            "label": "tokenFakeInitialVirtualLiq",
+            "offset": 0,
+            "slot": "10",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:120"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)158_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint8)dyn_storage": {
+            "label": "uint8[]",
+            "numberOfBytes": "32"
+          },
+          "t_bytes_storage": {
+            "label": "bytes",
+            "numberOfBytes": "32"
+          },
+          "t_contract(BondingConfig)2072": {
+            "label": "contract BondingConfig",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IAgentFactoryV7Minimal)2237": {
+            "label": "contract IAgentFactoryV7Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFFactoryV2Minimal)2110": {
+            "label": "contract IFFactoryV2Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFRouterV3Minimal)2172": {
+            "label": "contract IFRouterV3Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bytes_storage)": {
+            "label": "mapping(address => bytes)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(LaunchParams)1443_storage)": {
+            "label": "mapping(address => struct BondingConfig.LaunchParams)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Token)1432_storage)": {
+            "label": "mapping(address => struct BondingConfig.Token)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Data)1393_storage": {
+            "label": "struct BondingConfig.Data",
+            "members": [
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "ticker",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "supply",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "price",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "marketCap",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "liquidity",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "volume",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "volume24H",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "prevPrice",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "10"
+              },
+              {
+                "label": "lastUpdated",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "11"
+              }
+            ],
+            "numberOfBytes": "384"
+          },
+          "t_struct(LaunchParams)1443_storage": {
+            "label": "struct BondingConfig.LaunchParams",
+            "members": [
+              {
+                "label": "launchMode",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "airdropBips",
+                "type": "t_uint16",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "needAcf",
+                "type": "t_bool",
+                "offset": 3,
+                "slot": "0"
+              },
+              {
+                "label": "antiSniperTaxType",
+                "type": "t_uint8",
+                "offset": 4,
+                "slot": "0"
+              },
+              {
+                "label": "isProject60days",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Token)1432_storage": {
+            "label": "struct BondingConfig.Token",
+            "members": [
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "pair",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "agentToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "data",
+                "type": "t_struct(Data)1393_storage",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "description",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "16"
+              },
+              {
+                "label": "cores",
+                "type": "t_array(t_uint8)dyn_storage",
+                "offset": 0,
+                "slot": "17"
+              },
+              {
+                "label": "image",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "18"
+              },
+              {
+                "label": "twitter",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "19"
+              },
+              {
+                "label": "telegram",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "20"
+              },
+              {
+                "label": "youtube",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "21"
+              },
+              {
+                "label": "website",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "22"
+              },
+              {
+                "label": "trading",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "23"
+              },
+              {
+                "label": "tradingOnUniswap",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "23"
+              },
+              {
+                "label": "applicationId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "24"
+              },
+              {
+                "label": "initialPurchase",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "25"
+              },
+              {
+                "label": "virtualId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "26"
+              },
+              {
+                "label": "launchExecuted",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "27"
+              }
+            ],
+            "numberOfBytes": "896"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
               "offset": 0,
               "slot": "0"
             }

--- a/contracts/launchpadv2/BondingConfig.sol
+++ b/contracts/launchpadv2/BondingConfig.sol
@@ -120,9 +120,13 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
     /// @dev Appended in upgrade v2 — receives bonding-curve excess tokens at graduation to be burned.
     address public graduationExcessBurnWallet;
 
+    /// @dev Fake virtual liq for pre-upgrade tokens at graduation (BondingV5 mapping unset). Prod default: 6300.
+    uint256 public legacyInitialVirtualLiq;
+
     event DeployParamsUpdated(DeployParams params);
     event TeamTokenReservedWalletUpdated(address wallet);
     event GraduationExcessBurnWalletUpdated(address wallet);
+    event LegacyInitialVirtualLiqUpdated(uint256 legacyInitialVirtualLiq);
     event CommonParamsUpdated(uint256 initialSupply, address feeTo);
     event BondingCurveParamsUpdated(BondingCurveParams params);
     event AcfFakeInitialVirtualLiqUpdated(uint256 acfFakeInitialVirtualLiq);
@@ -216,6 +220,21 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
     }
 
     /**
+     * @notice Fake virtual liq for pre-upgrade tokens at graduation migration.
+     * @dev Pre-upgrade tokens have no `tokenFakeInitialVirtualLiq` in BondingV5 (prod default: 6300).
+     */
+    function setLegacyInitialVirtualLiq(
+        uint256 legacyInitialVirtualLiq_
+    ) external onlyOwner {
+        require(
+            legacyInitialVirtualLiq_ > 0,
+            "legacyInitialVirtualLiq cannot be zero"
+        );
+        legacyInitialVirtualLiq = legacyInitialVirtualLiq_;
+        emit LegacyInitialVirtualLiqUpdated(legacyInitialVirtualLiq_);
+    }
+
+    /**
      * @notice Calculate bonding curve supply with validation
      * @dev Validates:
      *      1. airdropBips_ <= reserveSupplyParams.maxAirdropBips
@@ -259,6 +278,13 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
         return needAcf_
             ? acfFakeInitialVirtualLiq
             : bondingCurveParams.fakeInitialVirtualLiq;
+    }
+
+    /**
+     * @notice Fake virtual liq for pre-upgrade tokens at graduation (BondingV5 mapping unset).
+     */
+    function getLegacyInitialVirtualLiq() external view returns (uint256) {
+        return legacyInitialVirtualLiq;
     }
 
     /**

--- a/contracts/launchpadv2/BondingConfig.sol
+++ b/contracts/launchpadv2/BondingConfig.sol
@@ -48,7 +48,7 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
 
     // Common bonding curve parameters (unified across all launch modes)
     struct BondingCurveParams {
-        uint256 fakeInitialVirtualLiq; // Fixed fake initial VIRTUAL liquidity (e.g., 6300 * 1e18)
+        uint256 fakeInitialVirtualLiq; // Normal launches (e.g., 6300 * 1e18)
         uint256 targetRealVirtual; // Target VIRTUAL from users at graduation (e.g., 42000 * 1e18)
     }
     BondingCurveParams public bondingCurveParams;
@@ -112,10 +112,16 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
     uint256 public initialSupply;
     address public feeTo;
 
+    /// @dev Appended in upgrade v2 — do not insert before `feeTo` (would shift prior slots).
+    /// Fake initial VIRTUAL for needAcf launches (e.g., 14000 * 1e18). Normal launches use
+    /// `bondingCurveParams.fakeInitialVirtualLiq`.
+    uint256 public acfFakeInitialVirtualLiq;
+
     event DeployParamsUpdated(DeployParams params);
     event TeamTokenReservedWalletUpdated(address wallet);
     event CommonParamsUpdated(uint256 initialSupply, address feeTo);
     event BondingCurveParamsUpdated(BondingCurveParams params);
+    event AcfFakeInitialVirtualLiqUpdated(uint256 acfFakeInitialVirtualLiq);
     event ReserveSupplyParamsUpdated(ReserveSupplyParams params);
     event PrivilegedLauncherUpdated(address indexed launcher, bool allowed);
 
@@ -135,7 +141,8 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
         ReserveSupplyParams memory reserveSupplyParams_,
         ScheduledLaunchParams memory scheduledLaunchParams_,
         DeployParams memory deployParams_,
-        BondingCurveParams memory bondingCurveParams_
+        BondingCurveParams memory bondingCurveParams_,
+        uint256 acfFakeInitialVirtualLiq_
     ) external initializer {
         __Ownable_init(msg.sender);
 
@@ -146,6 +153,8 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
         scheduledLaunchParams = scheduledLaunchParams_;
         deployParams = deployParams_;
         bondingCurveParams = bondingCurveParams_;
+        require(acfFakeInitialVirtualLiq_ > 0, "acfFakeInitialVirtualLiq cannot be zero");
+        acfFakeInitialVirtualLiq = acfFakeInitialVirtualLiq_;
     }
 
     /**
@@ -176,13 +185,20 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
      * @param params_ The bonding curve parameters (K, assetRate, targetRealVirtual)
      */
     function setBondingCurveParams(
-        BondingCurveParams memory params_
+        BondingCurveParams memory params_,
+        uint256 acfFakeInitialVirtualLiq_
     ) external onlyOwner {
         require(params_.fakeInitialVirtualLiq > 0, "fakeInitialVirtualLiq cannot be zero");
         require(params_.targetRealVirtual > 0, "targetRealVirtual cannot be zero");
-        
+        require(
+            acfFakeInitialVirtualLiq_ > 0,
+            "acfFakeInitialVirtualLiq cannot be zero"
+        );
+
         bondingCurveParams = params_;
+        acfFakeInitialVirtualLiq = acfFakeInitialVirtualLiq_;
         emit BondingCurveParamsUpdated(params_);
+        emit AcfFakeInitialVirtualLiqUpdated(acfFakeInitialVirtualLiq_);
     }
 
     /**
@@ -211,7 +227,7 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
     }
 
     /**
-     * @notice Get the fixed fake initial virtual liquidity
+     * @notice Get fake initial virtual liquidity for normal launches
      * @return fakeInitialVirtualLiq The fake initial VIRTUAL liquidity in wei
      */
     function getFakeInitialVirtualLiq() external view returns (uint256) {
@@ -219,18 +235,32 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
     }
 
     /**
+     * @notice Get fake initial virtual liquidity by launch type
+     * @param needAcf_ Whether the token launch requires ACF reserve
+     * @return fakeInitialVirtualLiq The fake initial VIRTUAL liquidity in wei
+     */
+    function getFakeInitialVirtualLiq(
+        bool needAcf_
+    ) external view returns (uint256) {
+        return needAcf_
+            ? acfFakeInitialVirtualLiq
+            : bondingCurveParams.fakeInitialVirtualLiq;
+    }
+
+    /**
      * @notice Calculate graduation threshold for a token
-     * @dev Formula: gradThreshold = fakeInitialVirtualLiq * bondingCurveSupply / (targetRealVirtual + fakeInitialVirtualLiq)
+     * @dev Formula: gradThreshold = y0 * x0 / (targetRealVirtual + y0)
      * @param bondingCurveSupplyWei_ Bonding curve supply in wei
+     * @param needAcf_ Whether the token launch requires ACF reserve
      * @return gradThreshold The graduation threshold (agent token amount in wei)
      */
     function calculateGradThreshold(
-        uint256 bondingCurveSupplyWei_
+        uint256 bondingCurveSupplyWei_,
+        bool needAcf_
     ) external view returns (uint256) {
-        // gradThreshold = y0 * x0 / (targetRealVirtual + y0)
-        // where y0 = fakeInitialVirtualLiq (fixed), x0 = bondingCurveSupply
-        uint256 fakeInitialVirtualLiq = bondingCurveParams
-            .fakeInitialVirtualLiq;
+        uint256 fakeInitialVirtualLiq = needAcf_
+            ? acfFakeInitialVirtualLiq
+            : bondingCurveParams.fakeInitialVirtualLiq;
         return
             (fakeInitialVirtualLiq * bondingCurveSupplyWei_) /
             (bondingCurveParams.targetRealVirtual + fakeInitialVirtualLiq);

--- a/contracts/launchpadv2/BondingConfig.sol
+++ b/contracts/launchpadv2/BondingConfig.sol
@@ -117,8 +117,12 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
     /// `bondingCurveParams.fakeInitialVirtualLiq`.
     uint256 public acfFakeInitialVirtualLiq;
 
+    /// @dev Appended in upgrade v2 — receives bonding-curve excess tokens at graduation to be burned.
+    address public graduationExcessBurnWallet;
+
     event DeployParamsUpdated(DeployParams params);
     event TeamTokenReservedWalletUpdated(address wallet);
+    event GraduationExcessBurnWalletUpdated(address wallet);
     event CommonParamsUpdated(uint256 initialSupply, address feeTo);
     event BondingCurveParamsUpdated(BondingCurveParams params);
     event AcfFakeInitialVirtualLiqUpdated(uint256 acfFakeInitialVirtualLiq);
@@ -155,6 +159,16 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
         bondingCurveParams = bondingCurveParams_;
         require(acfFakeInitialVirtualLiq_ > 0, "acfFakeInitialVirtualLiq cannot be zero");
         acfFakeInitialVirtualLiq = acfFakeInitialVirtualLiq_;
+    }
+
+    /**
+     * @notice Set wallet that receives excess bonding-curve tokens at graduation (to be burned off-chain).
+     */
+    function setGraduationExcessBurnWallet(
+        address wallet_
+    ) external onlyOwner {
+        graduationExcessBurnWallet = wallet_;
+        emit GraduationExcessBurnWalletUpdated(wallet_);
     }
 
     /**

--- a/contracts/launchpadv2/BondingV5.sol
+++ b/contracts/launchpadv2/BondingV5.sol
@@ -691,7 +691,6 @@ contract BondingV5 is
         if (fakeVirtualLiq == 0) {
             fakeVirtualLiq = bondingConfig.getLegacyInitialVirtualLiq();
         }
-        require(fakeVirtualLiq > 0, "Legacy initial virtual liq not set");
         uint256 lpTokenAmount = tokenBalance;
         if (fakeVirtualLiq > 0 && assetBalance > 0) {
             lpTokenAmount =

--- a/contracts/launchpadv2/BondingV5.sol
+++ b/contracts/launchpadv2/BondingV5.sol
@@ -114,6 +114,11 @@ contract BondingV5 is
     /// @notice Raw `extParams_` from `preLaunch` (per agent token). Backend can read as canonical payload; not updated by `setFeeDelegation`.
     mapping(address => bytes) public tokenPreLaunchExtParams;
 
+    /// @dev Appended in upgrade v2 — must remain last state variable (append-only layout).
+    /// Fake initial virtual liquidity frozen at preLaunch for migration price continuity.
+    /// If unset (pre-upgrade token), graduation falls back to normal fake liq (6300).
+    mapping(address => uint256) public tokenFakeInitialVirtualLiq;
+
     event PreLaunched(
         address indexed token,
         address indexed pair,
@@ -332,8 +337,8 @@ contract BondingV5 is
 
         require(_approval(address(router), token, bondingCurveSupply));
 
-        // Get fixed fake initial virtual liquidity
-        uint256 liquidity = bondingConfig.getFakeInitialVirtualLiq();
+        uint256 liquidity = bondingConfig.getFakeInitialVirtualLiq(needAcf_);
+        tokenFakeInitialVirtualLiq[token] = liquidity;
         uint256 price = bondingCurveSupply / liquidity;
 
         router.addInitialLiquidity(token, bondingCurveSupply, liquidity);
@@ -348,7 +353,8 @@ contract BondingV5 is
 
         // Calculate and store per-token graduation threshold
         uint256 gradThreshold = bondingConfig.calculateGradThreshold(
-            bondingCurveSupply
+            bondingCurveSupply,
+            needAcf_
         );
         tokenGradThreshold[token] = gradThreshold;
 
@@ -679,6 +685,21 @@ contract BondingV5 is
         uint256 assetBalance = pairContract.assetBalance();
         uint256 tokenBalance = pairContract.balance();
 
+        // Bonding reserves include fakeInitialVirtualLiq that was never deposited.
+        // Seed UniV2 with only the token share backed by real asset so FDV is continuous.
+        uint256 fakeVirtualLiq = tokenFakeInitialVirtualLiq[tokenAddress_];
+        // Pre-upgrade tokens: mapping unset — all were launched with normal fake liq (6300).
+        if (fakeVirtualLiq == 0) {
+            fakeVirtualLiq = bondingConfig.getFakeInitialVirtualLiq();
+        }
+        uint256 lpTokenAmount = tokenBalance;
+        if (fakeVirtualLiq > 0 && assetBalance > 0) {
+            lpTokenAmount =
+                (tokenBalance * assetBalance) /
+                (assetBalance + fakeVirtualLiq);
+        }
+        uint256 excessTokens = tokenBalance - lpTokenAmount;
+
         router.graduate(tokenAddress_);
 
         // previously initFromBondingCurve has two parts:
@@ -703,13 +724,20 @@ contract BondingV5 is
         // previously executeBondingCurveApplicationSalt will create agentToken and do two parts:
         //      1. (lpSupply = all left $preToken in prePairAddress) $agentToken mint to agentTokenAddress
         //      2. (vaultSupply = 1B - lpSupply) $agentToken mint to prePairAddress
-        // now only need to transfer (all left agentTokens) $agentTokens from agentFactoryV6Address to agentTokenAddress
-        IERC20(tokenAddress_).safeTransfer(tokenAddress_, tokenBalance);
+        if (excessTokens > 0) {
+            IERC20(tokenAddress_).safeTransfer(
+                bondingConfig.teamTokenReservedWallet(),
+                excessTokens
+            );
+        }
+
+        // Transfer LP-bound tokens to agent token for UniV2 seeding
+        IERC20(tokenAddress_).safeTransfer(tokenAddress_, lpTokenAmount);
         require(tokenRef.applicationId != 0, "ApplicationId not found");
         address agentToken = agentFactory.executeBondingCurveApplicationSalt(
             tokenRef.applicationId,
             tokenRef.data.supply / 1 ether, // totalSupply
-            tokenBalance / 1 ether, // lpSupply
+            lpTokenAmount / 1 ether, // lpSupply
             pairAddress, // vault
             keccak256(
                 abi.encodePacked(msg.sender, block.timestamp, tokenAddress_)

--- a/contracts/launchpadv2/BondingV5.sol
+++ b/contracts/launchpadv2/BondingV5.sol
@@ -116,7 +116,7 @@ contract BondingV5 is
 
     /// @dev Appended in upgrade v2 — must remain last state variable (append-only layout).
     /// Fake initial virtual liquidity frozen at preLaunch for migration price continuity.
-    /// If unset (pre-upgrade token), graduation falls back to normal fake liq (6300).
+    /// If unset (pre-upgrade token), graduation uses BondingConfig legacyInitialVirtualLiq.
     mapping(address => uint256) public tokenFakeInitialVirtualLiq;
 
     event PreLaunched(
@@ -688,10 +688,10 @@ contract BondingV5 is
         // Bonding reserves include fakeInitialVirtualLiq that was never deposited.
         // Seed UniV2 with only the token share backed by real asset so FDV is continuous.
         uint256 fakeVirtualLiq = tokenFakeInitialVirtualLiq[tokenAddress_];
-        // Pre-upgrade tokens: mapping unset — all were launched with normal fake liq (6300).
         if (fakeVirtualLiq == 0) {
-            fakeVirtualLiq = bondingConfig.getFakeInitialVirtualLiq();
+            fakeVirtualLiq = bondingConfig.getLegacyInitialVirtualLiq();
         }
+        require(fakeVirtualLiq > 0, "Legacy initial virtual liq not set");
         uint256 lpTokenAmount = tokenBalance;
         if (fakeVirtualLiq > 0 && assetBalance > 0) {
             lpTokenAmount =

--- a/contracts/launchpadv2/BondingV5.sol
+++ b/contracts/launchpadv2/BondingV5.sol
@@ -725,10 +725,8 @@ contract BondingV5 is
         //      1. (lpSupply = all left $preToken in prePairAddress) $agentToken mint to agentTokenAddress
         //      2. (vaultSupply = 1B - lpSupply) $agentToken mint to prePairAddress
         if (excessTokens > 0) {
-            IERC20(tokenAddress_).safeTransfer(
-                bondingConfig.teamTokenReservedWallet(),
-                excessTokens
-            );
+            address burnWallet = bondingConfig.graduationExcessBurnWallet();
+            IERC20(tokenAddress_).safeTransfer(burnWallet, excessTokens);
         }
 
         // Transfer LP-bound tokens to agent token for UniV2 seeding


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes bonding-curve launch math, upgradeable storage layout, and graduation token/LP allocation—core launch and migration economics with real fund and supply routing impact.
> 
> **Overview**
> Introduces a **separate fake initial virtual liquidity** for `needAcf` launches (via new `acfFakeInitialVirtualLiq` on `BondingConfig`) while normal launches keep the existing `bondingCurveParams.fakeInitialVirtualLiq`. **Graduation threshold** and **preLaunch pricing** now pick the fake liq based on `needAcf`.
> 
> On **BondingV5**, each token **freezes** the fake liq used at `preLaunch` in `tokenFakeInitialVirtualLiq`. At **graduation**, UniV2 seeding uses only the token amount **backed by real asset** (stripping the never-deposited fake virtual from the ratio); **excess pair tokens** go to `teamTokenReservedWallet`, and `lpSupply` passed to the agent factory matches the reduced LP amount. Pre-upgrade tokens with an unset mapping fall back to the normal fake liq (6300).
> 
> **BondingConfig** `initialize` / `setBondingCurveParams` signatures gain the ACF fake-liq parameter (upgrade v2 append-only storage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11cc98875ccdfbd2a7f9fdbaa27ccf08f5ab01f1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->