### PR TITLE
feat: add 98min sell side only sniper tax and both buy and sell tax

### DIFF
--- a/.openzeppelin/base-sepolia.json
+++ b/.openzeppelin/base-sepolia.json
@@ -58861,6 +58861,946 @@
           ]
         }
       }
+    },
+    "8fba3db04ec09ce81dd9cbc5671b72e039d1c2f3fd586d082b9835b67691e5ff": {
+      "address": "0xc8f1aB0430977bd5E43086BFB218fa9133B29D91",
+      "txHash": "0x3d5d75fd761623bb13c5a28addd3f17b6bfd6debd45bf6091083e12b5e39bf74",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "reserveSupplyParams",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_struct(ReserveSupplyParams)2368_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:26"
+          },
+          {
+            "label": "scheduledLaunchParams",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_struct(ScheduledLaunchParams)2390_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:43"
+          },
+          {
+            "label": "teamTokenReservedWallet",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:46"
+          },
+          {
+            "label": "isPrivilegedLauncher",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:49"
+          },
+          {
+            "label": "bondingCurveParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_struct(BondingCurveParams)2405_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:56"
+          },
+          {
+            "label": "deployParams",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_struct(DeployParams)2492_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:111"
+          },
+          {
+            "label": "initialSupply",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:114"
+          },
+          {
+            "label": "feeTo",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:115"
+          },
+          {
+            "label": "acfFakeInitialVirtualLiq",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:120"
+          },
+          {
+            "label": "graduationExcessBurnWallet",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:123"
+          },
+          {
+            "label": "legacyInitialVirtualLiq",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:126"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)151_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BondingCurveParams)2405_storage": {
+            "label": "struct BondingConfig.BondingCurveParams",
+            "members": [
+              {
+                "label": "fakeInitialVirtualLiq",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "targetRealVirtual",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(DeployParams)2492_storage": {
+            "label": "struct BondingConfig.DeployParams",
+            "members": [
+              {
+                "label": "tbaSalt",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tbaImplementation",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "daoVotingPeriod",
+                "type": "t_uint32",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "daoThreshold",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(ReserveSupplyParams)2368_storage": {
+            "label": "struct BondingConfig.ReserveSupplyParams",
+            "members": [
+              {
+                "label": "maxAirdropBips",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "maxTotalReservedBips",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              },
+              {
+                "label": "acfReservedBips",
+                "type": "t_uint16",
+                "offset": 4,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ScheduledLaunchParams)2390_storage": {
+            "label": "struct BondingConfig.ScheduledLaunchParams",
+            "members": [
+              {
+                "label": "startTimeDelay",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "normalLaunchFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "acfFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "7b10967aca7ffee1867583cfefcfba1225ee271a84b23769dd0ed41bf6aa9e30": {
+      "address": "0xd356B5C83cd17a04ec6B930E6b77eB9Cd92a8791",
+      "txHash": "0xe1939bd8c2e8139aa051c0cafab279ab768bd3ff5fd453dc75624931f0d05256",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(FFactoryV3)2488",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:48"
+          },
+          {
+            "label": "assetToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:49"
+          },
+          {
+            "label": "bondingV5",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IBondingV5ForRouter)3086",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:52"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(IBondingConfigForRouter)3101",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:53"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)145_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)230_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(FFactoryV3)2488": {
+            "label": "contract FFactoryV3",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IBondingConfigForRouter)3101": {
+            "label": "contract IBondingConfigForRouter",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IBondingV5ForRouter)3086": {
+            "label": "contract IBondingV5ForRouter",
+            "numberOfBytes": "20"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "7238b7222668e727d9879ed426da07c6e770dc198d52c9ae95fda7d21eca355e": {
+      "address": "0x1A0a5391Dc3A60B305ED7A8bfeeF1CAEa3cd0088",
+      "txHash": "0x650313a0ace0ce59ef1e8b709c5f233db46eb8392d82807e4b17cb523463f1b7",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "reserveSupplyParams",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_struct(ReserveSupplyParams)2368_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:26"
+          },
+          {
+            "label": "scheduledLaunchParams",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_struct(ScheduledLaunchParams)2393_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:43"
+          },
+          {
+            "label": "teamTokenReservedWallet",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:46"
+          },
+          {
+            "label": "isPrivilegedLauncher",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:49"
+          },
+          {
+            "label": "bondingCurveParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_struct(BondingCurveParams)2408_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:56"
+          },
+          {
+            "label": "deployParams",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_struct(DeployParams)2495_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:111"
+          },
+          {
+            "label": "initialSupply",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:114"
+          },
+          {
+            "label": "feeTo",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:115"
+          },
+          {
+            "label": "acfFakeInitialVirtualLiq",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:120"
+          },
+          {
+            "label": "graduationExcessBurnWallet",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:123"
+          },
+          {
+            "label": "legacyInitialVirtualLiq",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:126"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)151_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BondingCurveParams)2408_storage": {
+            "label": "struct BondingConfig.BondingCurveParams",
+            "members": [
+              {
+                "label": "fakeInitialVirtualLiq",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "targetRealVirtual",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(DeployParams)2495_storage": {
+            "label": "struct BondingConfig.DeployParams",
+            "members": [
+              {
+                "label": "tbaSalt",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tbaImplementation",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "daoVotingPeriod",
+                "type": "t_uint32",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "daoThreshold",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(ReserveSupplyParams)2368_storage": {
+            "label": "struct BondingConfig.ReserveSupplyParams",
+            "members": [
+              {
+                "label": "maxAirdropBips",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "maxTotalReservedBips",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              },
+              {
+                "label": "acfReservedBips",
+                "type": "t_uint16",
+                "offset": 4,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ScheduledLaunchParams)2393_storage": {
+            "label": "struct BondingConfig.ScheduledLaunchParams",
+            "members": [
+              {
+                "label": "startTimeDelay",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "normalLaunchFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "acfFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "e083e08ec775fb4fd5205c5d693b079df7017ea190e03b129b1a58c6e34950ad": {
+      "address": "0xB55f2f23E98F59b2772F04de564E7D1dd53FF04f",
+      "txHash": "0xfce768a677b68b654163aa5d3da006add6205276020b0bec5773e65224b4ea5a",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(FFactoryV3)5642",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:49"
+          },
+          {
+            "label": "assetToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:50"
+          },
+          {
+            "label": "bondingV5",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IBondingV5ForRouter)6240",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:53"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(IBondingConfigForRouter)6262",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:54"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)296_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(FFactoryV3)5642": {
+            "label": "contract FFactoryV3",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IBondingConfigForRouter)6262": {
+            "label": "contract IBondingConfigForRouter",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IBondingV5ForRouter)6240": {
+            "label": "contract IBondingV5ForRouter",
+            "numberOfBytes": "20"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/base.json
+++ b/.openzeppelin/base.json
@@ -30863,6 +30863,946 @@
           ]
         }
       }
+    },
+    "8fba3db04ec09ce81dd9cbc5671b72e039d1c2f3fd586d082b9835b67691e5ff": {
+      "address": "0xA3093e3fd160Fba69eaF0Cf5b98856c64D1b15e2",
+      "txHash": "0x8e6ecb87b336cfdc6d959c33e62356a80f6fcec6fbe5c9746af622c3bc1dbc3f",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "reserveSupplyParams",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_struct(ReserveSupplyParams)2368_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:26"
+          },
+          {
+            "label": "scheduledLaunchParams",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_struct(ScheduledLaunchParams)2390_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:43"
+          },
+          {
+            "label": "teamTokenReservedWallet",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:46"
+          },
+          {
+            "label": "isPrivilegedLauncher",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:49"
+          },
+          {
+            "label": "bondingCurveParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_struct(BondingCurveParams)2405_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:56"
+          },
+          {
+            "label": "deployParams",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_struct(DeployParams)2492_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:111"
+          },
+          {
+            "label": "initialSupply",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:114"
+          },
+          {
+            "label": "feeTo",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:115"
+          },
+          {
+            "label": "acfFakeInitialVirtualLiq",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:120"
+          },
+          {
+            "label": "graduationExcessBurnWallet",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:123"
+          },
+          {
+            "label": "legacyInitialVirtualLiq",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:126"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)151_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BondingCurveParams)2405_storage": {
+            "label": "struct BondingConfig.BondingCurveParams",
+            "members": [
+              {
+                "label": "fakeInitialVirtualLiq",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "targetRealVirtual",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(DeployParams)2492_storage": {
+            "label": "struct BondingConfig.DeployParams",
+            "members": [
+              {
+                "label": "tbaSalt",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tbaImplementation",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "daoVotingPeriod",
+                "type": "t_uint32",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "daoThreshold",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(ReserveSupplyParams)2368_storage": {
+            "label": "struct BondingConfig.ReserveSupplyParams",
+            "members": [
+              {
+                "label": "maxAirdropBips",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "maxTotalReservedBips",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              },
+              {
+                "label": "acfReservedBips",
+                "type": "t_uint16",
+                "offset": 4,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ScheduledLaunchParams)2390_storage": {
+            "label": "struct BondingConfig.ScheduledLaunchParams",
+            "members": [
+              {
+                "label": "startTimeDelay",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "normalLaunchFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "acfFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "7b10967aca7ffee1867583cfefcfba1225ee271a84b23769dd0ed41bf6aa9e30": {
+      "address": "0x511742959B50826c144Aa8715998daa3a92d237f",
+      "txHash": "0x9101f195f342d6b2dff87ed8633ff5c29476e94998ae290c57e899e8d9ceca6c",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(FFactoryV3)2488",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:48"
+          },
+          {
+            "label": "assetToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:49"
+          },
+          {
+            "label": "bondingV5",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IBondingV5ForRouter)3086",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:52"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(IBondingConfigForRouter)3101",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:53"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)145_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)230_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(FFactoryV3)2488": {
+            "label": "contract FFactoryV3",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IBondingConfigForRouter)3101": {
+            "label": "contract IBondingConfigForRouter",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IBondingV5ForRouter)3086": {
+            "label": "contract IBondingV5ForRouter",
+            "numberOfBytes": "20"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "7238b7222668e727d9879ed426da07c6e770dc198d52c9ae95fda7d21eca355e": {
+      "address": "0x03d3204925636a25ff2fe622918a6CB4B560a1b8",
+      "txHash": "0x9306e6f70620dddbe16d3dfb314c57bd73545261eeef388922ece9ae866e7395",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "reserveSupplyParams",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_struct(ReserveSupplyParams)2368_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:26"
+          },
+          {
+            "label": "scheduledLaunchParams",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_struct(ScheduledLaunchParams)2393_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:43"
+          },
+          {
+            "label": "teamTokenReservedWallet",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:46"
+          },
+          {
+            "label": "isPrivilegedLauncher",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:49"
+          },
+          {
+            "label": "bondingCurveParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_struct(BondingCurveParams)2408_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:56"
+          },
+          {
+            "label": "deployParams",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_struct(DeployParams)2495_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:111"
+          },
+          {
+            "label": "initialSupply",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:114"
+          },
+          {
+            "label": "feeTo",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:115"
+          },
+          {
+            "label": "acfFakeInitialVirtualLiq",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:120"
+          },
+          {
+            "label": "graduationExcessBurnWallet",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:123"
+          },
+          {
+            "label": "legacyInitialVirtualLiq",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:126"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)151_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BondingCurveParams)2408_storage": {
+            "label": "struct BondingConfig.BondingCurveParams",
+            "members": [
+              {
+                "label": "fakeInitialVirtualLiq",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "targetRealVirtual",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(DeployParams)2495_storage": {
+            "label": "struct BondingConfig.DeployParams",
+            "members": [
+              {
+                "label": "tbaSalt",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tbaImplementation",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "daoVotingPeriod",
+                "type": "t_uint32",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "daoThreshold",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(ReserveSupplyParams)2368_storage": {
+            "label": "struct BondingConfig.ReserveSupplyParams",
+            "members": [
+              {
+                "label": "maxAirdropBips",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "maxTotalReservedBips",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              },
+              {
+                "label": "acfReservedBips",
+                "type": "t_uint16",
+                "offset": 4,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ScheduledLaunchParams)2393_storage": {
+            "label": "struct BondingConfig.ScheduledLaunchParams",
+            "members": [
+              {
+                "label": "startTimeDelay",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "normalLaunchFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "acfFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "e083e08ec775fb4fd5205c5d693b079df7017ea190e03b129b1a58c6e34950ad": {
+      "address": "0x58377381523e86d66F9f29016371335dDcB89d32",
+      "txHash": "0x2e42b9fb63397590ba9f9f2abd4ffe5691c51dd8ce835e049127716c6b4bf71f",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(FFactoryV3)5642",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:49"
+          },
+          {
+            "label": "assetToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:50"
+          },
+          {
+            "label": "bondingV5",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IBondingV5ForRouter)6240",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:53"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(IBondingConfigForRouter)6262",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:54"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)296_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(FFactoryV3)5642": {
+            "label": "contract FFactoryV3",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IBondingConfigForRouter)6262": {
+            "label": "contract IBondingConfigForRouter",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IBondingV5ForRouter)6240": {
+            "label": "contract IBondingV5ForRouter",
+            "numberOfBytes": "20"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-4663.json
+++ b/.openzeppelin/unknown-4663.json
@@ -1060,7 +1060,7 @@
             "label": "factory",
             "offset": 0,
             "slot": "0",
-            "type": "t_contract(FFactoryV3)47632",
+            "type": "t_contract(FFactoryV3)10627",
             "contract": "FRouterV3",
             "src": "contracts/launchpadv2/FRouterV3.sol:48"
           },
@@ -1076,7 +1076,7 @@
             "label": "bondingV5",
             "offset": 0,
             "slot": "2",
-            "type": "t_contract(IBondingV5ForRouter)49564",
+            "type": "t_contract(IBondingV5ForRouter)12559",
             "contract": "FRouterV3",
             "src": "contracts/launchpadv2/FRouterV3.sol:52"
           },
@@ -1084,7 +1084,7 @@
             "label": "bondingConfig",
             "offset": 0,
             "slot": "3",
-            "type": "t_contract(IBondingConfigForRouter)49577",
+            "type": "t_contract(IBondingConfigForRouter)12572",
             "contract": "FRouterV3",
             "src": "contracts/launchpadv2/FRouterV3.sol:53"
           }
@@ -1106,23 +1106,23 @@
             "label": "mapping(address => bool)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_bytes32,t_struct(RoleData)460_storage)": {
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
             "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
             "numberOfBytes": "32"
           },
-          "t_struct(AccessControlStorage)470_storage": {
+          "t_struct(AccessControlStorage)34_storage": {
             "label": "struct AccessControlUpgradeable.AccessControlStorage",
             "members": [
               {
                 "label": "_roles",
-                "type": "t_mapping(t_bytes32,t_struct(RoleData)460_storage)",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
                 "offset": 0,
                 "slot": "0"
               }
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(InitializableStorage)1948_storage": {
+          "t_struct(InitializableStorage)211_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -1140,7 +1140,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(ReentrancyGuardStorage)2967_storage": {
+          "t_struct(ReentrancyGuardStorage)296_storage": {
             "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
             "members": [
               {
@@ -1152,7 +1152,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(RoleData)460_storage": {
+          "t_struct(RoleData)24_storage": {
             "label": "struct AccessControlUpgradeable.RoleData",
             "members": [
               {
@@ -1178,15 +1178,15 @@
             "label": "uint64",
             "numberOfBytes": "8"
           },
-          "t_contract(FFactoryV3)47632": {
+          "t_contract(FFactoryV3)10627": {
             "label": "contract FFactoryV3",
             "numberOfBytes": "20"
           },
-          "t_contract(IBondingConfigForRouter)49577": {
+          "t_contract(IBondingConfigForRouter)12572": {
             "label": "contract IBondingConfigForRouter",
             "numberOfBytes": "20"
           },
-          "t_contract(IBondingV5ForRouter)49564": {
+          "t_contract(IBondingV5ForRouter)12559": {
             "label": "contract IBondingV5ForRouter",
             "numberOfBytes": "20"
           }
@@ -1206,7 +1206,7 @@
             {
               "contract": "AccessControlUpgradeable",
               "label": "_roles",
-              "type": "t_mapping(t_bytes32,t_struct(RoleData)460_storage)",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
               "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
               "offset": 0,
               "slot": "0"
@@ -2561,6 +2561,476 @@
               "label": "_status",
               "type": "t_uint256",
               "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "7238b7222668e727d9879ed426da07c6e770dc198d52c9ae95fda7d21eca355e": {
+      "address": "0x2686937F7342d4183f13331d12Df090A555A0d4C",
+      "txHash": "0xe48c682d177aac629bd4666d43d27bc8c4ba9b652d13b6bea5ec73036f855dae",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "reserveSupplyParams",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_struct(ReserveSupplyParams)2368_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:26"
+          },
+          {
+            "label": "scheduledLaunchParams",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_struct(ScheduledLaunchParams)2393_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:43"
+          },
+          {
+            "label": "teamTokenReservedWallet",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:46"
+          },
+          {
+            "label": "isPrivilegedLauncher",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:49"
+          },
+          {
+            "label": "bondingCurveParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_struct(BondingCurveParams)2408_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:56"
+          },
+          {
+            "label": "deployParams",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_struct(DeployParams)2495_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:111"
+          },
+          {
+            "label": "initialSupply",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:114"
+          },
+          {
+            "label": "feeTo",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:115"
+          },
+          {
+            "label": "acfFakeInitialVirtualLiq",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:120"
+          },
+          {
+            "label": "graduationExcessBurnWallet",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:123"
+          },
+          {
+            "label": "legacyInitialVirtualLiq",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:126"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)151_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BondingCurveParams)2408_storage": {
+            "label": "struct BondingConfig.BondingCurveParams",
+            "members": [
+              {
+                "label": "fakeInitialVirtualLiq",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "targetRealVirtual",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(DeployParams)2495_storage": {
+            "label": "struct BondingConfig.DeployParams",
+            "members": [
+              {
+                "label": "tbaSalt",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tbaImplementation",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "daoVotingPeriod",
+                "type": "t_uint32",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "daoThreshold",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(ReserveSupplyParams)2368_storage": {
+            "label": "struct BondingConfig.ReserveSupplyParams",
+            "members": [
+              {
+                "label": "maxAirdropBips",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "maxTotalReservedBips",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              },
+              {
+                "label": "acfReservedBips",
+                "type": "t_uint16",
+                "offset": 4,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ScheduledLaunchParams)2393_storage": {
+            "label": "struct BondingConfig.ScheduledLaunchParams",
+            "members": [
+              {
+                "label": "startTimeDelay",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "normalLaunchFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "acfFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "e083e08ec775fb4fd5205c5d693b079df7017ea190e03b129b1a58c6e34950ad": {
+      "address": "0x09256b9D607c53fD946681F7C5a7a4381ba285A1",
+      "txHash": "0x9ad6a8ec66feab55e51c1bd3dc3ff6179a1a2a038ba5830337d059f101aecd83",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(FFactoryV3)5642",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:49"
+          },
+          {
+            "label": "assetToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:50"
+          },
+          {
+            "label": "bondingV5",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IBondingV5ForRouter)6240",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:53"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(IBondingConfigForRouter)6262",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:54"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)296_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(FFactoryV3)5642": {
+            "label": "contract FFactoryV3",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IBondingConfigForRouter)6262": {
+            "label": "contract IBondingConfigForRouter",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IBondingV5ForRouter)6240": {
+            "label": "contract IBondingV5ForRouter",
+            "numberOfBytes": "20"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
               "offset": 0,
               "slot": "0"
             }

--- a/.openzeppelin/unknown-46630.json
+++ b/.openzeppelin/unknown-46630.json
@@ -1060,7 +1060,7 @@
             "label": "factory",
             "offset": 0,
             "slot": "0",
-            "type": "t_contract(FFactoryV3)47632",
+            "type": "t_contract(FFactoryV3)10627",
             "contract": "FRouterV3",
             "src": "contracts/launchpadv2/FRouterV3.sol:48"
           },
@@ -1076,7 +1076,7 @@
             "label": "bondingV5",
             "offset": 0,
             "slot": "2",
-            "type": "t_contract(IBondingV5ForRouter)49564",
+            "type": "t_contract(IBondingV5ForRouter)12559",
             "contract": "FRouterV3",
             "src": "contracts/launchpadv2/FRouterV3.sol:52"
           },
@@ -1084,7 +1084,7 @@
             "label": "bondingConfig",
             "offset": 0,
             "slot": "3",
-            "type": "t_contract(IBondingConfigForRouter)49577",
+            "type": "t_contract(IBondingConfigForRouter)12572",
             "contract": "FRouterV3",
             "src": "contracts/launchpadv2/FRouterV3.sol:53"
           }
@@ -1106,23 +1106,23 @@
             "label": "mapping(address => bool)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_bytes32,t_struct(RoleData)460_storage)": {
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
             "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
             "numberOfBytes": "32"
           },
-          "t_struct(AccessControlStorage)470_storage": {
+          "t_struct(AccessControlStorage)34_storage": {
             "label": "struct AccessControlUpgradeable.AccessControlStorage",
             "members": [
               {
                 "label": "_roles",
-                "type": "t_mapping(t_bytes32,t_struct(RoleData)460_storage)",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
                 "offset": 0,
                 "slot": "0"
               }
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(InitializableStorage)1948_storage": {
+          "t_struct(InitializableStorage)211_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -1140,7 +1140,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(ReentrancyGuardStorage)2967_storage": {
+          "t_struct(ReentrancyGuardStorage)296_storage": {
             "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
             "members": [
               {
@@ -1152,7 +1152,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(RoleData)460_storage": {
+          "t_struct(RoleData)24_storage": {
             "label": "struct AccessControlUpgradeable.RoleData",
             "members": [
               {
@@ -1178,15 +1178,15 @@
             "label": "uint64",
             "numberOfBytes": "8"
           },
-          "t_contract(FFactoryV3)47632": {
+          "t_contract(FFactoryV3)10627": {
             "label": "contract FFactoryV3",
             "numberOfBytes": "20"
           },
-          "t_contract(IBondingConfigForRouter)49577": {
+          "t_contract(IBondingConfigForRouter)12572": {
             "label": "contract IBondingConfigForRouter",
             "numberOfBytes": "20"
           },
-          "t_contract(IBondingV5ForRouter)49564": {
+          "t_contract(IBondingV5ForRouter)12559": {
             "label": "contract IBondingV5ForRouter",
             "numberOfBytes": "20"
           }
@@ -1206,7 +1206,7 @@
             {
               "contract": "AccessControlUpgradeable",
               "label": "_roles",
-              "type": "t_mapping(t_bytes32,t_struct(RoleData)460_storage)",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
               "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
               "offset": 0,
               "slot": "0"
@@ -2529,6 +2529,476 @@
               "label": "_status",
               "type": "t_uint256",
               "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "7238b7222668e727d9879ed426da07c6e770dc198d52c9ae95fda7d21eca355e": {
+      "address": "0x8d2cB249F39f16A58ce5c801427d63A9737B65a3",
+      "txHash": "0x801305703cb5db649cecc0508591e36b3d937092cdf886b619c304d86e34d642",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "reserveSupplyParams",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_struct(ReserveSupplyParams)2368_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:26"
+          },
+          {
+            "label": "scheduledLaunchParams",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_struct(ScheduledLaunchParams)2393_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:43"
+          },
+          {
+            "label": "teamTokenReservedWallet",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:46"
+          },
+          {
+            "label": "isPrivilegedLauncher",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:49"
+          },
+          {
+            "label": "bondingCurveParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_struct(BondingCurveParams)2408_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:56"
+          },
+          {
+            "label": "deployParams",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_struct(DeployParams)2495_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:111"
+          },
+          {
+            "label": "initialSupply",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:114"
+          },
+          {
+            "label": "feeTo",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:115"
+          },
+          {
+            "label": "acfFakeInitialVirtualLiq",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:120"
+          },
+          {
+            "label": "graduationExcessBurnWallet",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:123"
+          },
+          {
+            "label": "legacyInitialVirtualLiq",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:126"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)151_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BondingCurveParams)2408_storage": {
+            "label": "struct BondingConfig.BondingCurveParams",
+            "members": [
+              {
+                "label": "fakeInitialVirtualLiq",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "targetRealVirtual",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(DeployParams)2495_storage": {
+            "label": "struct BondingConfig.DeployParams",
+            "members": [
+              {
+                "label": "tbaSalt",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tbaImplementation",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "daoVotingPeriod",
+                "type": "t_uint32",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "daoThreshold",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(ReserveSupplyParams)2368_storage": {
+            "label": "struct BondingConfig.ReserveSupplyParams",
+            "members": [
+              {
+                "label": "maxAirdropBips",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "maxTotalReservedBips",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              },
+              {
+                "label": "acfReservedBips",
+                "type": "t_uint16",
+                "offset": 4,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ScheduledLaunchParams)2393_storage": {
+            "label": "struct BondingConfig.ScheduledLaunchParams",
+            "members": [
+              {
+                "label": "startTimeDelay",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "normalLaunchFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "acfFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "e083e08ec775fb4fd5205c5d693b079df7017ea190e03b129b1a58c6e34950ad": {
+      "address": "0x2686937F7342d4183f13331d12Df090A555A0d4C",
+      "txHash": "0xa777ecdb9d13a3208dc980458775a6ad83ba9919f8b9f73931fdf4178e0f6d87",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(FFactoryV3)5642",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:49"
+          },
+          {
+            "label": "assetToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:50"
+          },
+          {
+            "label": "bondingV5",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IBondingV5ForRouter)6240",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:53"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(IBondingConfigForRouter)6262",
+            "contract": "FRouterV3",
+            "src": "contracts/launchpadv2/FRouterV3.sol:54"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)296_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(FFactoryV3)5642": {
+            "label": "contract FFactoryV3",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IBondingConfigForRouter)6262": {
+            "label": "contract IBondingConfigForRouter",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IBondingV5ForRouter)6240": {
+            "label": "contract IBondingV5ForRouter",
+            "numberOfBytes": "20"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
               "offset": 0,
               "slot": "0"
             }

--- a/contracts/launchpadv2/BondingConfig.sol
+++ b/contracts/launchpadv2/BondingConfig.sol
@@ -25,13 +25,13 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
     }
     ReserveSupplyParams public reserveSupplyParams;
 
-  // Anti-sniper tax type constants
-  // Buy-side types: duration over which buy anti-sniper tax decreases from 99% to 0%
-  uint8 public constant ANTI_SNIPER_NONE = 0; // No anti-sniper tax (0 seconds)
-  uint8 public constant ANTI_SNIPER_60S = 1; // 60 seconds duration (default)
-  uint8 public constant ANTI_SNIPER_98M = 2; // 98 minutes duration
-  // Sell-only: same linear decay on sells only (no buy anti-sniper tax)
-  uint8 public constant ANTI_SNIPER_24H_SELL = 3; // 24 hours sell-only duration
+    // Anti-sniper tax type constants
+    // Buy-side: duration over which buy anti-sniper tax decreases from 99% to 0%
+    uint8 public constant ANTI_SNIPER_NONE = 0; // No anti-sniper tax (0 seconds)
+    uint8 public constant ANTI_SNIPER_60S = 1; // 60 seconds buy-only (default)
+    uint8 public constant ANTI_SNIPER_98M = 2; // 98 minutes buy-only
+    uint8 public constant ANTI_SNIPER_98M_SELL = 3; // 98 minutes sell-only
+    uint8 public constant ANTI_SNIPER_98M_BOTH = 4; // 98 minutes buy and sell
 
     // Scheduled launch parameters
     struct ScheduledLaunchParams {
@@ -364,7 +364,7 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
 
     /**
      * @notice Check if anti-sniper tax type is valid
-     * @param antiSniperType_ The anti-sniper type (0=none, 1=60s, 2=98min, 3=24h sell-only)
+     * @param antiSniperType_ 0=none, 1=60s buy, 2=98m buy, 3=98m sell, 4=98m both
      * @return Whether the type is valid
      */
     function isValidAntiSniperType(
@@ -374,22 +374,37 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
             antiSniperType_ == ANTI_SNIPER_NONE ||
             antiSniperType_ == ANTI_SNIPER_60S ||
             antiSniperType_ == ANTI_SNIPER_98M ||
-            antiSniperType_ == ANTI_SNIPER_24H_SELL;
+            antiSniperType_ == ANTI_SNIPER_98M_SELL ||
+            antiSniperType_ == ANTI_SNIPER_98M_BOTH;
     }
 
     /**
-     * @notice Whether anti-sniper tax applies to sells only (not buys)
+     * @notice Whether anti-sniper tax applies on buys for this type
      */
-    function isSellOnlyAntiSniperType(
+    function appliesAntiSniperOnBuy(
         uint8 antiSniperType_
     ) external pure returns (bool) {
-        return antiSniperType_ == ANTI_SNIPER_24H_SELL;
+        return
+            antiSniperType_ == ANTI_SNIPER_60S ||
+            antiSniperType_ == ANTI_SNIPER_98M ||
+            antiSniperType_ == ANTI_SNIPER_98M_BOTH;
+    }
+
+    /**
+     * @notice Whether anti-sniper tax applies on sells for this type
+     */
+    function appliesAntiSniperOnSell(
+        uint8 antiSniperType_
+    ) external pure returns (bool) {
+        return
+            antiSniperType_ == ANTI_SNIPER_98M_SELL ||
+            antiSniperType_ == ANTI_SNIPER_98M_BOTH;
     }
 
     /**
      * @notice Get anti-sniper tax duration in seconds for a given type
      * @param antiSniperType_ The anti-sniper type
-     * @return Duration in seconds (0 for NONE, 60 for 60S, 5880 for 98M, 86400 for 24H_SELL)
+     * @return Duration in seconds (0 for NONE, 60 for 60S, 5880 for 98M variants)
      */
     function getAntiSniperDuration(
         uint8 antiSniperType_
@@ -398,10 +413,12 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
             return 0;
         } else if (antiSniperType_ == ANTI_SNIPER_60S) {
             return 60; // 60 seconds
-        } else if (antiSniperType_ == ANTI_SNIPER_98M) {
+        } else if (
+            antiSniperType_ == ANTI_SNIPER_98M ||
+            antiSniperType_ == ANTI_SNIPER_98M_SELL ||
+            antiSniperType_ == ANTI_SNIPER_98M_BOTH
+        ) {
             return 5880; // 98 minutes = 98 * 60 = 5880 seconds
-        } else if (antiSniperType_ == ANTI_SNIPER_24H_SELL) {
-            return 86400; // 24 hours
         }
         revert InvalidAntiSniperType();
     }

--- a/contracts/launchpadv2/BondingConfig.sol
+++ b/contracts/launchpadv2/BondingConfig.sol
@@ -25,11 +25,13 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
     }
     ReserveSupplyParams public reserveSupplyParams;
 
-    // Anti-sniper tax type constants
-    // These define the duration over which anti-sniper tax decreases from 99% to 0%
-    uint8 public constant ANTI_SNIPER_NONE = 0; // No anti-sniper tax (0 seconds)
-    uint8 public constant ANTI_SNIPER_60S = 1; // 60 seconds duration (default)
-    uint8 public constant ANTI_SNIPER_98M = 2; // 98 minutes duration
+  // Anti-sniper tax type constants
+  // Buy-side types: duration over which buy anti-sniper tax decreases from 99% to 0%
+  uint8 public constant ANTI_SNIPER_NONE = 0; // No anti-sniper tax (0 seconds)
+  uint8 public constant ANTI_SNIPER_60S = 1; // 60 seconds duration (default)
+  uint8 public constant ANTI_SNIPER_98M = 2; // 98 minutes duration
+  // Sell-only: same linear decay on sells only (no buy anti-sniper tax)
+  uint8 public constant ANTI_SNIPER_24H_SELL = 3; // 24 hours sell-only duration
 
     // Scheduled launch parameters
     struct ScheduledLaunchParams {
@@ -362,7 +364,7 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
 
     /**
      * @notice Check if anti-sniper tax type is valid
-     * @param antiSniperType_ The anti-sniper type (0=none, 1=60s, 2=98min)
+     * @param antiSniperType_ The anti-sniper type (0=none, 1=60s, 2=98min, 3=24h sell-only)
      * @return Whether the type is valid
      */
     function isValidAntiSniperType(
@@ -371,13 +373,23 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
         return
             antiSniperType_ == ANTI_SNIPER_NONE ||
             antiSniperType_ == ANTI_SNIPER_60S ||
-            antiSniperType_ == ANTI_SNIPER_98M;
+            antiSniperType_ == ANTI_SNIPER_98M ||
+            antiSniperType_ == ANTI_SNIPER_24H_SELL;
+    }
+
+    /**
+     * @notice Whether anti-sniper tax applies to sells only (not buys)
+     */
+    function isSellOnlyAntiSniperType(
+        uint8 antiSniperType_
+    ) external pure returns (bool) {
+        return antiSniperType_ == ANTI_SNIPER_24H_SELL;
     }
 
     /**
      * @notice Get anti-sniper tax duration in seconds for a given type
      * @param antiSniperType_ The anti-sniper type
-     * @return Duration in seconds (0 for NONE, 60 for 60S, 5880 for 98M)
+     * @return Duration in seconds (0 for NONE, 60 for 60S, 5880 for 98M, 86400 for 24H_SELL)
      */
     function getAntiSniperDuration(
         uint8 antiSniperType_
@@ -388,6 +400,8 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
             return 60; // 60 seconds
         } else if (antiSniperType_ == ANTI_SNIPER_98M) {
             return 5880; // 98 minutes = 98 * 60 = 5880 seconds
+        } else if (antiSniperType_ == ANTI_SNIPER_24H_SELL) {
+            return 86400; // 24 hours
         }
         revert InvalidAntiSniperType();
     }

--- a/contracts/launchpadv2/FRouterV3.sol
+++ b/contracts/launchpadv2/FRouterV3.sol
@@ -26,7 +26,8 @@ interface IBondingV5ForRouter {
 // Minimal interface for BondingConfig to get anti-sniper duration
 interface IBondingConfigForRouter {
     function getAntiSniperDuration(uint8 antiSniperType_) external pure returns (uint256);
-    function isSellOnlyAntiSniperType(uint8 antiSniperType_) external pure returns (bool);
+    function appliesAntiSniperOnBuy(uint8 antiSniperType_) external pure returns (bool);
+    function appliesAntiSniperOnSell(uint8 antiSniperType_) external pure returns (bool);
 }
 
 // Minimal interface for AgentTax to deposit tax with on-chain attribution
@@ -204,7 +205,7 @@ contract FRouterV3 is
         if (isInitialPurchase) {
             // No anti-sniper tax for creator's initial purchase
         } else {
-            antiSniperTax = _calculateAntiSniperTax(pair); // Anti-sniper tax for regular purchases
+            antiSniperTax = _calculateAntiSniperBuyTax(pair);
         }
         // Ensure total tax does not exceed 99% (user must receive at least 1%)
         if (normalTax + antiSniperTax > 99) {
@@ -288,29 +289,26 @@ contract FRouterV3 is
     }
 
     /**
-     * @dev Calculate buy-side anti-sniper tax based on time elapsed since tax start
-     * BondingV5 tokens: NONE=0s, 60S=60s, 98M=98min (buy only); 24H_SELL=0 on buys
-     * @param pairAddress The address of the pair
-     * @return taxPercentage Tax in percentage (1 = 1%)
+     * @dev Calculate buy-side anti-sniper tax (60S, 98M, 98M_BOTH on BondingV5)
      */
-    function _calculateAntiSniperTax(
-        address pairAddress
-    ) private view returns (uint256) {
-        return _calculateAntiSniperTaxForSide(pairAddress, false);
-    }
-
-    /**
-     * @dev Calculate sell-side anti-sniper tax (24H_SELL only on BondingV5)
-     */
-    function _calculateAntiSniperSellTax(
+    function _calculateAntiSniperBuyTax(
         address pairAddress
     ) private view returns (uint256) {
         return _calculateAntiSniperTaxForSide(pairAddress, true);
     }
 
+    /**
+     * @dev Calculate sell-side anti-sniper tax (98M_SELL, 98M_BOTH on BondingV5)
+     */
+    function _calculateAntiSniperSellTax(
+        address pairAddress
+    ) private view returns (uint256) {
+        return _calculateAntiSniperTaxForSide(pairAddress, false);
+    }
+
     function _calculateAntiSniperTaxForSide(
         address pairAddress,
-        bool isSell
+        bool isBuy
     ) private view returns (uint256) {
         IFPairV2 pair = IFPairV2(pairAddress);
 
@@ -320,8 +318,11 @@ contract FRouterV3 is
         uint256 startTax = factory.antiSniperBuyTaxStartValue(); // 99%
 
         uint8 antiSniperType = bondingV5.tokenAntiSniperType(tokenAddress);
-        bool sellOnly = bondingConfig.isSellOnlyAntiSniperType(antiSniperType);
-        if (isSell != sellOnly) {
+        if (isBuy) {
+            if (!bondingConfig.appliesAntiSniperOnBuy(antiSniperType)) {
+                return 0;
+            }
+        } else if (!bondingConfig.appliesAntiSniperOnSell(antiSniperType)) {
             return 0;
         }
 
@@ -372,10 +373,9 @@ contract FRouterV3 is
     }
 
     function hasAntiSniperTax(address pairAddress) public view returns (bool) {
-        if (_calculateAntiSniperTax(pairAddress) > 0 || _calculateAntiSniperSellTax(pairAddress) > 0) {
-            return true;
-        }
-        return false;
+        return
+            _calculateAntiSniperBuyTax(pairAddress) > 0 ||
+            _calculateAntiSniperSellTax(pairAddress) > 0;
     }
 
     function setTaxStartTime(

--- a/contracts/launchpadv2/FRouterV3.sol
+++ b/contracts/launchpadv2/FRouterV3.sol
@@ -372,7 +372,10 @@ contract FRouterV3 is
     }
 
     function hasAntiSniperTax(address pairAddress) public view returns (bool) {
-        return _calculateAntiSniperTax(pairAddress) > 0;
+        if (_calculateAntiSniperTax(pairAddress) > 0 || _calculateAntiSniperSellTax(pairAddress) > 0) {
+            return true;
+        }
+        return false;
     }
 
     function setTaxStartTime(

--- a/contracts/launchpadv2/FRouterV3.sol
+++ b/contracts/launchpadv2/FRouterV3.sol
@@ -26,7 +26,7 @@ interface IBondingV5ForRouter {
 // Minimal interface for BondingConfig to get anti-sniper duration
 interface IBondingConfigForRouter {
     function getAntiSniperDuration(uint8 antiSniperType_) external pure returns (uint256);
-    function ANTI_SNIPER_NONE() external pure returns (uint8);
+    function isSellOnlyAntiSniperType(uint8 antiSniperType_) external pure returns (bool);
 }
 
 // Minimal interface for AgentTax to deposit tax with on-chain attribution
@@ -155,17 +155,31 @@ contract FRouterV3 is
 
         token.safeTransferFrom(to, pairAddress, amountIn);
 
-        uint fee = factory.sellTax();
-        uint256 txFee = (fee * amountOut) / 100;
+        uint256 normalTax = factory.sellTax();
+        uint256 antiSniperTax = _calculateAntiSniperSellTax(pairAddress);
+        if (normalTax + antiSniperTax > 99) {
+            antiSniperTax = 99 - normalTax;
+        }
 
-        uint256 amount = amountOut - txFee;
+        uint256 normalTxFee = (normalTax * amountOut) / 100;
+        uint256 antiSniperTxFee = (antiSniperTax * amountOut) / 100;
+
+        uint256 amount = amountOut - normalTxFee - antiSniperTxFee;
         address feeTo = factory.taxVault();
 
         pair.transferAsset(to, amount);
-        // Transfer tax from pair to router, then deposit with on-chain attribution
-        pair.transferAsset(address(this), txFee);
-        IERC20(assetToken).forceApprove(feeTo, txFee);
-        IAgentTaxForRouter(feeTo).depositTax(tokenAddress, txFee);
+        // Transfer normal sell tax from pair to router, then deposit with on-chain attribution
+        pair.transferAsset(address(this), normalTxFee);
+        IERC20(assetToken).forceApprove(feeTo, normalTxFee);
+        IAgentTaxForRouter(feeTo).depositTax(tokenAddress, normalTxFee);
+
+        // Anti-sniper sell tax goes to separate vault (no attribution needed)
+        if (antiSniperTxFee > 0) {
+            pair.transferAsset(
+                factory.antiSniperTaxVault(),
+                antiSniperTxFee
+            );
+        }
 
         pair.swap(amountIn, 0, 0, amountOut);
 
@@ -274,15 +288,29 @@ contract FRouterV3 is
     }
 
     /**
-     * @dev Calculate anti-sniper tax based on time elapsed since pair start
-     * BondingV5 tokens: Use configurable anti-sniper types (NONE=0s, 60S=60s, 98M=98min)
-     * BondingV4 X_LAUNCH tokens: Tax decreases from 99% to 0% over 99 seconds
-     * Legacy tokens: Tax decreases from 99% to 0% over 99 minutes
+     * @dev Calculate buy-side anti-sniper tax based on time elapsed since tax start
+     * BondingV5 tokens: NONE=0s, 60S=60s, 98M=98min (buy only); 24H_SELL=0 on buys
      * @param pairAddress The address of the pair
      * @return taxPercentage Tax in percentage (1 = 1%)
      */
     function _calculateAntiSniperTax(
         address pairAddress
+    ) private view returns (uint256) {
+        return _calculateAntiSniperTaxForSide(pairAddress, false);
+    }
+
+    /**
+     * @dev Calculate sell-side anti-sniper tax (24H_SELL only on BondingV5)
+     */
+    function _calculateAntiSniperSellTax(
+        address pairAddress
+    ) private view returns (uint256) {
+        return _calculateAntiSniperTaxForSide(pairAddress, true);
+    }
+
+    function _calculateAntiSniperTaxForSide(
+        address pairAddress,
+        bool isSell
     ) private view returns (uint256) {
         IFPairV2 pair = IFPairV2(pairAddress);
 
@@ -292,29 +320,34 @@ contract FRouterV3 is
         uint256 startTax = factory.antiSniperBuyTaxStartValue(); // 99%
 
         uint8 antiSniperType = bondingV5.tokenAntiSniperType(tokenAddress);
+        bool sellOnly = bondingConfig.isSellOnlyAntiSniperType(antiSniperType);
+        if (isSell != sellOnly) {
+            return 0;
+        }
+
         // Get the duration for this anti-sniper type
         uint256 duration = bondingConfig.getAntiSniperDuration(antiSniperType);
-        
+
         // ANTI_SNIPER_NONE: no tax at all
         if (duration == 0) {
             return 0;
         }
-        
+
         // Get tax start time
         uint256 taxStartTime = _getTaxStartTime(pair);
-        
+
         // If trading hasn't started yet, use maximum tax
         if (block.timestamp < taxStartTime) {
             return startTax;
         }
-        
+
         uint256 timeElapsed = block.timestamp - taxStartTime;
-        
+
         // If time elapsed exceeds duration, no tax
         if (timeElapsed >= duration) {
             return 0;
         }
-        
+
         // Linear decrease: tax = startTax * (duration - timeElapsed) / duration
         return startTax * (duration - timeElapsed) / duration;
     }

--- a/test/launchpadv5/bondingV5.js
+++ b/test/launchpadv5/bondingV5.js
@@ -46,6 +46,8 @@ const ACF_RESERVED_BIPS = 5000; // ACF operations reserve 50%
 const ANTI_SNIPER_NONE = 0;
 const ANTI_SNIPER_60S = 1;
 const ANTI_SNIPER_98M = 2;
+const ANTI_SNIPER_98M_SELL = 3;
+const ANTI_SNIPER_98M_BOTH = 4;
 
 // Fee structure
 const NORMAL_LAUNCH_FEE = ethers.parseEther("100"); // Fee for scheduled/marketing launches
@@ -904,7 +906,11 @@ describe("BondingV5", function () {
         .true;
       expect(await bondingConfig.isValidAntiSniperType(ANTI_SNIPER_98M)).to.be
         .true;
-      expect(await bondingConfig.isValidAntiSniperType(3)).to.be.false;
+      expect(await bondingConfig.isValidAntiSniperType(ANTI_SNIPER_98M_SELL)).to.be
+        .true;
+      expect(await bondingConfig.isValidAntiSniperType(ANTI_SNIPER_98M_BOTH)).to.be
+        .true;
+      expect(await bondingConfig.isValidAntiSniperType(6)).to.be.false;
     });
 
     it("Should return correct durations for anti-sniper types", async function () {
@@ -919,6 +925,24 @@ describe("BondingV5", function () {
       expect(
         await bondingConfig.getAntiSniperDuration(ANTI_SNIPER_98M)
       ).to.equal(98 * 60);
+      expect(
+        await bondingConfig.getAntiSniperDuration(ANTI_SNIPER_98M_SELL)
+      ).to.equal(98 * 60);
+      expect(
+        await bondingConfig.getAntiSniperDuration(ANTI_SNIPER_98M_BOTH)
+      ).to.equal(98 * 60);
+      expect(
+        await bondingConfig.appliesAntiSniperOnBuy(ANTI_SNIPER_98M_SELL)
+      ).to.be.false;
+      expect(
+        await bondingConfig.appliesAntiSniperOnSell(ANTI_SNIPER_98M_SELL)
+      ).to.be.true;
+      expect(
+        await bondingConfig.appliesAntiSniperOnBuy(ANTI_SNIPER_98M_BOTH)
+      ).to.be.true;
+      expect(
+        await bondingConfig.appliesAntiSniperOnSell(ANTI_SNIPER_98M_BOTH)
+      ).to.be.true;
     });
 
     it("Should revert preLaunch with invalid anti-sniper type", async function () {
@@ -945,10 +969,184 @@ describe("BondingV5", function () {
           LAUNCH_MODE_NORMAL,
           0,
           false,
-          5, // Invalid anti-sniper type
+          6, // Invalid anti-sniper type
           false
         ,"0x")
       ).to.be.revertedWithCustomError(bondingV5, "InvalidAntiSniperType");
+    });
+
+    it("Should collect sell-only anti-sniper tax for ANTI_SNIPER_98M_SELL and no buy anti-sniper tax", async function () {
+      const { user1, user2 } = accounts;
+      const { bondingV5, virtualToken, fRouterV3, fFactoryV3 } = contracts;
+
+      const purchaseAmount = ethers.parseEther("1000");
+      await virtualToken
+        .connect(user1)
+        .approve(addresses.bondingV5, purchaseAmount);
+      await virtualToken
+        .connect(user2)
+        .approve(addresses.bondingV5, ethers.MaxUint256);
+      await virtualToken
+        .connect(user2)
+        .approve(addresses.fRouterV3, ethers.MaxUint256);
+
+      const startTime = (await time.latest()) + START_TIME_DELAY + 1;
+      const tx = await bondingV5.connect(user1).preLaunch(
+        "98m Sell Sniper Tax",
+        "S98M",
+        [0, 1, 2],
+        "Description",
+        "https://example.com/image.png",
+        ["", "", "", ""],
+        purchaseAmount,
+        startTime,
+        LAUNCH_MODE_NORMAL,
+        0,
+        false,
+        ANTI_SNIPER_98M_SELL,
+        false,
+        "0x"
+      );
+
+      const receipt = await tx.wait();
+      const event = receipt.logs.find((log) => {
+        try {
+          return bondingV5.interface.parseLog(log)?.name === "PreLaunched";
+        } catch (e) {
+          return false;
+        }
+      });
+      const tokenAddress = bondingV5.interface.parseLog(event).args.token;
+      const pairAddress = bondingV5.interface.parseLog(event).args.pair;
+
+      await time.increase(START_TIME_DELAY + 1);
+      await bondingV5.launch(tokenAddress);
+
+      const antiSniperTaxVault = await fFactoryV3.antiSniperTaxVault();
+      const antiSniperVaultBeforeBuy = await virtualToken.balanceOf(
+        antiSniperTaxVault
+      );
+
+      expect(await fRouterV3.hasAntiSniperTax(pairAddress)).to.be.true;
+
+      await bondingV5
+        .connect(user2)
+        .buy(ethers.parseEther("500"), tokenAddress, 0, (await time.latest()) + 300);
+
+      const antiSniperVaultAfterBuy = await virtualToken.balanceOf(
+        antiSniperTaxVault
+      );
+      expect(antiSniperVaultAfterBuy).to.equal(antiSniperVaultBeforeBuy);
+
+      const agentToken = await ethers.getContractAt("AgentTokenV4", tokenAddress);
+      const tokenBalance = await agentToken.balanceOf(user2.address);
+      await agentToken
+        .connect(user2)
+        .approve(addresses.bondingV5, tokenBalance);
+      await agentToken
+        .connect(user2)
+        .approve(addresses.fRouterV3, tokenBalance);
+
+      const antiSniperVaultBeforeSell = await virtualToken.balanceOf(
+        antiSniperTaxVault
+      );
+      const sellAmount = tokenBalance / 4n;
+
+      await bondingV5
+        .connect(user2)
+        .sell(sellAmount, tokenAddress, 0, (await time.latest()) + 300);
+
+      const antiSniperVaultAfterSell = await virtualToken.balanceOf(
+        antiSniperTaxVault
+      );
+      expect(antiSniperVaultAfterSell).to.be.gt(antiSniperVaultBeforeSell);
+    });
+
+    it("Should collect anti-sniper tax on both buy and sell for ANTI_SNIPER_98M_BOTH", async function () {
+      const { user1, user2 } = accounts;
+      const { bondingV5, virtualToken, fRouterV3, fFactoryV3 } = contracts;
+
+      const purchaseAmount = ethers.parseEther("1000");
+      await virtualToken
+        .connect(user1)
+        .approve(addresses.bondingV5, purchaseAmount);
+      await virtualToken
+        .connect(user2)
+        .approve(addresses.bondingV5, ethers.MaxUint256);
+      await virtualToken
+        .connect(user2)
+        .approve(addresses.fRouterV3, ethers.MaxUint256);
+
+      const startTime = (await time.latest()) + START_TIME_DELAY + 1;
+      const tx = await bondingV5.connect(user1).preLaunch(
+        "98m Both Sniper Tax",
+        "B98M",
+        [0, 1, 2],
+        "Description",
+        "https://example.com/image.png",
+        ["", "", "", ""],
+        purchaseAmount,
+        startTime,
+        LAUNCH_MODE_NORMAL,
+        0,
+        false,
+        ANTI_SNIPER_98M_BOTH,
+        false,
+        "0x"
+      );
+
+      const receipt = await tx.wait();
+      const event = receipt.logs.find((log) => {
+        try {
+          return bondingV5.interface.parseLog(log)?.name === "PreLaunched";
+        } catch (e) {
+          return false;
+        }
+      });
+      const tokenAddress = bondingV5.interface.parseLog(event).args.token;
+      const pairAddress = bondingV5.interface.parseLog(event).args.pair;
+
+      await time.increase(START_TIME_DELAY + 1);
+      await bondingV5.launch(tokenAddress);
+
+      const antiSniperTaxVault = await fFactoryV3.antiSniperTaxVault();
+      const antiSniperVaultBeforeBuy = await virtualToken.balanceOf(
+        antiSniperTaxVault
+      );
+
+      expect(await fRouterV3.hasAntiSniperTax(pairAddress)).to.be.true;
+
+      await bondingV5
+        .connect(user2)
+        .buy(ethers.parseEther("500"), tokenAddress, 0, (await time.latest()) + 300);
+
+      const antiSniperVaultAfterBuy = await virtualToken.balanceOf(
+        antiSniperTaxVault
+      );
+      expect(antiSniperVaultAfterBuy).to.be.gt(antiSniperVaultBeforeBuy);
+
+      const agentToken = await ethers.getContractAt("AgentTokenV4", tokenAddress);
+      const tokenBalance = await agentToken.balanceOf(user2.address);
+      await agentToken
+        .connect(user2)
+        .approve(addresses.bondingV5, tokenBalance);
+      await agentToken
+        .connect(user2)
+        .approve(addresses.fRouterV3, tokenBalance);
+
+      const antiSniperVaultBeforeSell = await virtualToken.balanceOf(
+        antiSniperTaxVault
+      );
+      const sellAmount = tokenBalance / 4n;
+
+      await bondingV5
+        .connect(user2)
+        .sell(sellAmount, tokenAddress, 0, (await time.latest()) + 300);
+
+      const antiSniperVaultAfterSell = await virtualToken.balanceOf(
+        antiSniperTaxVault
+      );
+      expect(antiSniperVaultAfterSell).to.be.gt(antiSniperVaultBeforeSell);
     });
   });
 
@@ -1405,6 +1603,92 @@ describe("BondingV5", function () {
 
         expect(await bondingV5.tokenAntiSniperType(tokenAddress)).to.equal(
           ANTI_SNIPER_98M
+        );
+      });
+
+      it("Should create token with ANTI_SNIPER_98M_SELL (98m sell-only duration)", async function () {
+        const { user1 } = accounts;
+        const { bondingV5, virtualToken } = contracts;
+
+        const purchaseAmount = ethers.parseEther("1000");
+        await virtualToken
+          .connect(user1)
+          .approve(addresses.bondingV5, purchaseAmount);
+
+        const startTime = (await time.latest()) + START_TIME_DELAY + 1;
+        const tx = await bondingV5
+          .connect(user1)
+          .preLaunch(
+            "98m Sell Anti-Sniper",
+            "AS98S",
+            [0, 1],
+            "Description",
+            "https://example.com/image.png",
+            ["", "", "", ""],
+            purchaseAmount,
+            startTime,
+            LAUNCH_MODE_NORMAL,
+            0,
+            false,
+            ANTI_SNIPER_98M_SELL,
+            false
+          ,"0x");
+
+        const receipt = await tx.wait();
+        const event = receipt.logs.find((log) => {
+          try {
+            return bondingV5.interface.parseLog(log)?.name === "PreLaunched";
+          } catch (e) {
+            return false;
+          }
+        });
+        const tokenAddress = bondingV5.interface.parseLog(event).args.token;
+
+        expect(await bondingV5.tokenAntiSniperType(tokenAddress)).to.equal(
+          ANTI_SNIPER_98M_SELL
+        );
+      });
+
+      it("Should create token with ANTI_SNIPER_98M_BOTH (98m buy and sell duration)", async function () {
+        const { user1 } = accounts;
+        const { bondingV5, virtualToken } = contracts;
+
+        const purchaseAmount = ethers.parseEther("1000");
+        await virtualToken
+          .connect(user1)
+          .approve(addresses.bondingV5, purchaseAmount);
+
+        const startTime = (await time.latest()) + START_TIME_DELAY + 1;
+        const tx = await bondingV5
+          .connect(user1)
+          .preLaunch(
+            "98m Both Anti-Sniper",
+            "AS98B",
+            [0, 1],
+            "Description",
+            "https://example.com/image.png",
+            ["", "", "", ""],
+            purchaseAmount,
+            startTime,
+            LAUNCH_MODE_NORMAL,
+            0,
+            false,
+            ANTI_SNIPER_98M_BOTH,
+            false
+          ,"0x");
+
+        const receipt = await tx.wait();
+        const event = receipt.logs.find((log) => {
+          try {
+            return bondingV5.interface.parseLog(log)?.name === "PreLaunched";
+          } catch (e) {
+            return false;
+          }
+        });
+        const tokenAddress = bondingV5.interface.parseLog(event).args.token;
+
+        expect(await bondingV5.tokenAntiSniperType(tokenAddress)).to.equal(
+          ANTI_SNIPER_98M_BOTH
         );
       });
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes live swap fee math and asset routing on sells in FRouterV3, which directly affects user proceeds and treasury vault balances for bonding-curve trades.
> 
> **Overview**
> Adds a new BondingV5 anti-sniper mode **`ANTI_SNIPER_24H_SELL` (type 3)** with a **24-hour** linear decay from 99% to 0%, documented as **sell-only** (no buy anti-sniper). **`BondingConfig`** extends validation (`isValidAntiSniperType`), duration lookup, and a new **`isSellOnlyAntiSniperType`** helper.
> 
> **`FRouterV3`** splits anti-sniper calculation into buy vs sell paths via **`_calculateAntiSniperTaxForSide`**, so existing buy-side types stay on buys and the new type only taxes sells. **`sell()`** now mirrors buy behavior: normal sell tax still goes to **`taxVault`** / **`depositTax`**, while anti-sniper sell tax is capped with normal tax (max 99% combined) and sent to **`antiSniperTaxVault`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c999a04678a0cc64fe52240a55689b8a81d2af11. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->