### PR TITLE
supoort RH contract verification

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -277,8 +277,8 @@ module.exports = {
         network: "robinhood_testnet",
         chainId: 46630,
         urls: {
-          apiURL: "https://explorer.testnet.chain.robinhood.com/api",
-          browserURL: "https://explorer.testnet.chain.robinhood.com",
+          apiURL: "https://robinhoodchain-testnet.blockscout.com/api",
+          browserURL: "https://robinhoodchain-testnet.blockscout.com",
         },
       },
       // X Layer (OKLink) — kept for reference only. Verification uses okxweb3explorer (okverify) below.
@@ -305,8 +305,8 @@ module.exports = {
         network: "robinhood_mainnet",
         chainId: 4663,
         urls: {
-          apiURL: "https://explorer.chain.robinhood.com/api",
-          browserURL: "https://explorer.chain.robinhood.com",
+          apiURL: "https://robinhoodchain.blockscout.com/api",
+          browserURL: "https://robinhoodchain.blockscout.com",
         },
       },
     ],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only URL changes for contract verification; no deploy or runtime contract logic is affected.
> 
> **Overview**
> Updates Hardhat **etherscan** `customChains` URLs for Robinhood so `hardhat verify` hits Blockscout instead of the old Robinhood-hosted explorers.
> 
> For **`robinhood_testnet`** (46630), `apiURL` / `browserURL` now use `robinhoodchain-testnet.blockscout.com`. For **`robinhood_mainnet`** (4663), they use `robinhoodchain.blockscout.com`. RPC and `apiKey` behavior are unchanged; this only retargets where verification requests and explorer links go.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35ecfa0f5d218d0b33d2623c11f003bd61bf3067. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->