### PR TITLE
feat: add 8 min buy tax

### DIFF
--- a/.openzeppelin/base-sepolia.json
+++ b/.openzeppelin/base-sepolia.json
@@ -59812,7 +59812,7 @@
             "label": "factory",
             "offset": 0,
             "slot": "0",
-            "type": "t_contract(IFFactoryV2Minimal)3207",
+            "type": "t_contract(IFFactoryV2Minimal)2188",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:95"
           },
@@ -59820,7 +59820,7 @@
             "label": "router",
             "offset": 0,
             "slot": "1",
-            "type": "t_contract(IFRouterV3Minimal)3269",
+            "type": "t_contract(IFRouterV3Minimal)2250",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:96"
           },
@@ -59828,7 +59828,7 @@
             "label": "agentFactory",
             "offset": 0,
             "slot": "2",
-            "type": "t_contract(IAgentFactoryV7Minimal)3334",
+            "type": "t_contract(IAgentFactoryV7Minimal)2315",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:97"
           },
@@ -59836,7 +59836,7 @@
             "label": "bondingConfig",
             "offset": 0,
             "slot": "3",
-            "type": "t_contract(BondingConfig)3169",
+            "type": "t_contract(BondingConfig)2150",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:98"
           },
@@ -59844,7 +59844,7 @@
             "label": "tokenInfo",
             "offset": 0,
             "slot": "4",
-            "type": "t_mapping(t_address,t_struct(Token)2475_storage)",
+            "type": "t_mapping(t_address,t_struct(Token)1441_storage)",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:100"
           },
@@ -59860,7 +59860,7 @@
             "label": "tokenLaunchParams",
             "offset": 0,
             "slot": "6",
-            "type": "t_mapping(t_address,t_struct(LaunchParams)2486_storage)",
+            "type": "t_mapping(t_address,t_struct(LaunchParams)1452_storage)",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:107"
           },
@@ -59906,7 +59906,7 @@
             "label": "bool",
             "numberOfBytes": "1"
           },
-          "t_struct(InitializableStorage)211_storage": {
+          "t_struct(InitializableStorage)73_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -59924,7 +59924,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(OwnableStorage)151_storage": {
+          "t_struct(OwnableStorage)13_storage": {
             "label": "struct OwnableUpgradeable.OwnableStorage",
             "members": [
               {
@@ -59936,7 +59936,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(ReentrancyGuardStorage)296_storage": {
+          "t_struct(ReentrancyGuardStorage)158_storage": {
             "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
             "members": [
               {
@@ -59968,19 +59968,19 @@
             "label": "bytes",
             "numberOfBytes": "32"
           },
-          "t_contract(BondingConfig)3169": {
+          "t_contract(BondingConfig)2150": {
             "label": "contract BondingConfig",
             "numberOfBytes": "20"
           },
-          "t_contract(IAgentFactoryV7Minimal)3334": {
+          "t_contract(IAgentFactoryV7Minimal)2315": {
             "label": "contract IAgentFactoryV7Minimal",
             "numberOfBytes": "20"
           },
-          "t_contract(IFFactoryV2Minimal)3207": {
+          "t_contract(IFFactoryV2Minimal)2188": {
             "label": "contract IFFactoryV2Minimal",
             "numberOfBytes": "20"
           },
-          "t_contract(IFRouterV3Minimal)3269": {
+          "t_contract(IFRouterV3Minimal)2250": {
             "label": "contract IFRouterV3Minimal",
             "numberOfBytes": "20"
           },
@@ -59992,11 +59992,11 @@
             "label": "mapping(address => bytes)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_address,t_struct(LaunchParams)2486_storage)": {
+          "t_mapping(t_address,t_struct(LaunchParams)1452_storage)": {
             "label": "mapping(address => struct BondingConfig.LaunchParams)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_address,t_struct(Token)2475_storage)": {
+          "t_mapping(t_address,t_struct(Token)1441_storage)": {
             "label": "mapping(address => struct BondingConfig.Token)",
             "numberOfBytes": "32"
           },
@@ -60008,7 +60008,7 @@
             "label": "string",
             "numberOfBytes": "32"
           },
-          "t_struct(Data)2436_storage": {
+          "t_struct(Data)1402_storage": {
             "label": "struct BondingConfig.Data",
             "members": [
               {
@@ -60086,7 +60086,7 @@
             ],
             "numberOfBytes": "384"
           },
-          "t_struct(LaunchParams)2486_storage": {
+          "t_struct(LaunchParams)1452_storage": {
             "label": "struct BondingConfig.LaunchParams",
             "members": [
               {
@@ -60122,7 +60122,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(Token)2475_storage": {
+          "t_struct(Token)1441_storage": {
             "label": "struct BondingConfig.Token",
             "members": [
               {
@@ -60151,7 +60151,779 @@
               },
               {
                 "label": "data",
-                "type": "t_struct(Data)2436_storage",
+                "type": "t_struct(Data)1402_storage",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "description",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "16"
+              },
+              {
+                "label": "cores",
+                "type": "t_array(t_uint8)dyn_storage",
+                "offset": 0,
+                "slot": "17"
+              },
+              {
+                "label": "image",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "18"
+              },
+              {
+                "label": "twitter",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "19"
+              },
+              {
+                "label": "telegram",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "20"
+              },
+              {
+                "label": "youtube",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "21"
+              },
+              {
+                "label": "website",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "22"
+              },
+              {
+                "label": "trading",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "23"
+              },
+              {
+                "label": "tradingOnUniswap",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "23"
+              },
+              {
+                "label": "applicationId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "24"
+              },
+              {
+                "label": "initialPurchase",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "25"
+              },
+              {
+                "label": "virtualId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "26"
+              },
+              {
+                "label": "launchExecuted",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "27"
+              }
+            ],
+            "numberOfBytes": "896"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "bf421ce14be84cdf10bcc11697529a43d61b7c06b3fc26d41dc441563094b5d9": {
+      "address": "0x5932e8409a5166F8ec0128bc8e0c6e9488a0f5E0",
+      "txHash": "0x13233826d3e9f6e7935c4faea81aa64ddf8957d1923e41d447523ef19a19edc2",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "reserveSupplyParams",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_struct(ReserveSupplyParams)1331_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:26"
+          },
+          {
+            "label": "scheduledLaunchParams",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_struct(ScheduledLaunchParams)1359_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:44"
+          },
+          {
+            "label": "teamTokenReservedWallet",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:47"
+          },
+          {
+            "label": "isPrivilegedLauncher",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:50"
+          },
+          {
+            "label": "bondingCurveParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_struct(BondingCurveParams)1374_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:57"
+          },
+          {
+            "label": "deployParams",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_struct(DeployParams)1461_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:112"
+          },
+          {
+            "label": "initialSupply",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:115"
+          },
+          {
+            "label": "feeTo",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:116"
+          },
+          {
+            "label": "acfFakeInitialVirtualLiq",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:121"
+          },
+          {
+            "label": "graduationExcessBurnWallet",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:124"
+          },
+          {
+            "label": "legacyInitialVirtualLiq",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BondingCurveParams)1374_storage": {
+            "label": "struct BondingConfig.BondingCurveParams",
+            "members": [
+              {
+                "label": "fakeInitialVirtualLiq",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "targetRealVirtual",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(DeployParams)1461_storage": {
+            "label": "struct BondingConfig.DeployParams",
+            "members": [
+              {
+                "label": "tbaSalt",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tbaImplementation",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "daoVotingPeriod",
+                "type": "t_uint32",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "daoThreshold",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(ReserveSupplyParams)1331_storage": {
+            "label": "struct BondingConfig.ReserveSupplyParams",
+            "members": [
+              {
+                "label": "maxAirdropBips",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "maxTotalReservedBips",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              },
+              {
+                "label": "acfReservedBips",
+                "type": "t_uint16",
+                "offset": 4,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ScheduledLaunchParams)1359_storage": {
+            "label": "struct BondingConfig.ScheduledLaunchParams",
+            "members": [
+              {
+                "label": "startTimeDelay",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "normalLaunchFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "acfFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "4d4ef2d622d9d80c9a7d21b5224290452ee8ae3875b37b60efe2b518531dbcdc": {
+      "address": "0x7b793164eFb6D99fff69400a6D307eee0B98E616",
+      "txHash": "0x91dc6b1c69da189a3996b1628055e47e0ea55b3e8c6e4a765dc000bd7db2c1b0",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(IFFactoryV2Minimal)2188",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:95"
+          },
+          {
+            "label": "router",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_contract(IFRouterV3Minimal)2250",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:96"
+          },
+          {
+            "label": "agentFactory",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IAgentFactoryV7Minimal)2315",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:97"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(BondingConfig)2150",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:98"
+          },
+          {
+            "label": "tokenInfo",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_struct(Token)1441_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:100"
+          },
+          {
+            "label": "tokenInfos",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:101"
+          },
+          {
+            "label": "tokenLaunchParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_address,t_struct(LaunchParams)1452_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:107"
+          },
+          {
+            "label": "tokenGradThreshold",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:110"
+          },
+          {
+            "label": "isFeeDelegation",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:112"
+          },
+          {
+            "label": "tokenPreLaunchExtParams",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_mapping(t_address,t_bytes_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:115"
+          },
+          {
+            "label": "tokenFakeInitialVirtualLiq",
+            "offset": 0,
+            "slot": "10",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:120"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)158_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint8)dyn_storage": {
+            "label": "uint8[]",
+            "numberOfBytes": "32"
+          },
+          "t_bytes_storage": {
+            "label": "bytes",
+            "numberOfBytes": "32"
+          },
+          "t_contract(BondingConfig)2150": {
+            "label": "contract BondingConfig",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IAgentFactoryV7Minimal)2315": {
+            "label": "contract IAgentFactoryV7Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFFactoryV2Minimal)2188": {
+            "label": "contract IFFactoryV2Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFRouterV3Minimal)2250": {
+            "label": "contract IFRouterV3Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bytes_storage)": {
+            "label": "mapping(address => bytes)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(LaunchParams)1452_storage)": {
+            "label": "mapping(address => struct BondingConfig.LaunchParams)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Token)1441_storage)": {
+            "label": "mapping(address => struct BondingConfig.Token)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Data)1402_storage": {
+            "label": "struct BondingConfig.Data",
+            "members": [
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "ticker",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "supply",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "price",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "marketCap",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "liquidity",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "volume",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "volume24H",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "prevPrice",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "10"
+              },
+              {
+                "label": "lastUpdated",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "11"
+              }
+            ],
+            "numberOfBytes": "384"
+          },
+          "t_struct(LaunchParams)1452_storage": {
+            "label": "struct BondingConfig.LaunchParams",
+            "members": [
+              {
+                "label": "launchMode",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "airdropBips",
+                "type": "t_uint16",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "needAcf",
+                "type": "t_bool",
+                "offset": 3,
+                "slot": "0"
+              },
+              {
+                "label": "antiSniperTaxType",
+                "type": "t_uint8",
+                "offset": 4,
+                "slot": "0"
+              },
+              {
+                "label": "isProject60days",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Token)1441_storage": {
+            "label": "struct BondingConfig.Token",
+            "members": [
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "pair",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "agentToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "data",
+                "type": "t_struct(Data)1402_storage",
                 "offset": 0,
                 "slot": "4"
               },

--- a/.openzeppelin/base.json
+++ b/.openzeppelin/base.json
@@ -31344,7 +31344,7 @@
             "label": "reserveSupplyParams",
             "offset": 0,
             "slot": "0",
-            "type": "t_struct(ReserveSupplyParams)2368_storage",
+            "type": "t_struct(ReserveSupplyParams)1331_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:26"
           },
@@ -31352,7 +31352,7 @@
             "label": "scheduledLaunchParams",
             "offset": 0,
             "slot": "1",
-            "type": "t_struct(ScheduledLaunchParams)2393_storage",
+            "type": "t_struct(ScheduledLaunchParams)1356_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:43"
           },
@@ -31376,7 +31376,7 @@
             "label": "bondingCurveParams",
             "offset": 0,
             "slot": "6",
-            "type": "t_struct(BondingCurveParams)2408_storage",
+            "type": "t_struct(BondingCurveParams)1371_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:56"
           },
@@ -31384,7 +31384,7 @@
             "label": "deployParams",
             "offset": 0,
             "slot": "8",
-            "type": "t_struct(DeployParams)2495_storage",
+            "type": "t_struct(DeployParams)1458_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:111"
           },
@@ -31438,7 +31438,7 @@
             "label": "bool",
             "numberOfBytes": "1"
           },
-          "t_struct(InitializableStorage)211_storage": {
+          "t_struct(InitializableStorage)73_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -31456,7 +31456,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(OwnableStorage)151_storage": {
+          "t_struct(OwnableStorage)13_storage": {
             "label": "struct OwnableUpgradeable.OwnableStorage",
             "members": [
               {
@@ -31480,7 +31480,7 @@
             "label": "mapping(address => bool)",
             "numberOfBytes": "32"
           },
-          "t_struct(BondingCurveParams)2408_storage": {
+          "t_struct(BondingCurveParams)1371_storage": {
             "label": "struct BondingConfig.BondingCurveParams",
             "members": [
               {
@@ -31498,7 +31498,7 @@
             ],
             "numberOfBytes": "64"
           },
-          "t_struct(DeployParams)2495_storage": {
+          "t_struct(DeployParams)1458_storage": {
             "label": "struct BondingConfig.DeployParams",
             "members": [
               {
@@ -31528,7 +31528,7 @@
             ],
             "numberOfBytes": "96"
           },
-          "t_struct(ReserveSupplyParams)2368_storage": {
+          "t_struct(ReserveSupplyParams)1331_storage": {
             "label": "struct BondingConfig.ReserveSupplyParams",
             "members": [
               {
@@ -31552,7 +31552,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(ScheduledLaunchParams)2393_storage": {
+          "t_struct(ScheduledLaunchParams)1356_storage": {
             "label": "struct BondingConfig.ScheduledLaunchParams",
             "members": [
               {
@@ -31814,7 +31814,7 @@
             "label": "factory",
             "offset": 0,
             "slot": "0",
-            "type": "t_contract(IFFactoryV2Minimal)3207",
+            "type": "t_contract(IFFactoryV2Minimal)2170",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:95"
           },
@@ -31822,7 +31822,7 @@
             "label": "router",
             "offset": 0,
             "slot": "1",
-            "type": "t_contract(IFRouterV3Minimal)3269",
+            "type": "t_contract(IFRouterV3Minimal)2232",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:96"
           },
@@ -31830,7 +31830,7 @@
             "label": "agentFactory",
             "offset": 0,
             "slot": "2",
-            "type": "t_contract(IAgentFactoryV7Minimal)3334",
+            "type": "t_contract(IAgentFactoryV7Minimal)2297",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:97"
           },
@@ -31838,7 +31838,7 @@
             "label": "bondingConfig",
             "offset": 0,
             "slot": "3",
-            "type": "t_contract(BondingConfig)3169",
+            "type": "t_contract(BondingConfig)2132",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:98"
           },
@@ -31846,7 +31846,7 @@
             "label": "tokenInfo",
             "offset": 0,
             "slot": "4",
-            "type": "t_mapping(t_address,t_struct(Token)2475_storage)",
+            "type": "t_mapping(t_address,t_struct(Token)1438_storage)",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:100"
           },
@@ -31862,7 +31862,7 @@
             "label": "tokenLaunchParams",
             "offset": 0,
             "slot": "6",
-            "type": "t_mapping(t_address,t_struct(LaunchParams)2486_storage)",
+            "type": "t_mapping(t_address,t_struct(LaunchParams)1449_storage)",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:107"
           },
@@ -31908,7 +31908,7 @@
             "label": "bool",
             "numberOfBytes": "1"
           },
-          "t_struct(InitializableStorage)211_storage": {
+          "t_struct(InitializableStorage)73_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -31926,7 +31926,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(OwnableStorage)151_storage": {
+          "t_struct(OwnableStorage)13_storage": {
             "label": "struct OwnableUpgradeable.OwnableStorage",
             "members": [
               {
@@ -31938,7 +31938,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(ReentrancyGuardStorage)296_storage": {
+          "t_struct(ReentrancyGuardStorage)158_storage": {
             "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
             "members": [
               {
@@ -31970,19 +31970,19 @@
             "label": "bytes",
             "numberOfBytes": "32"
           },
-          "t_contract(BondingConfig)3169": {
+          "t_contract(BondingConfig)2132": {
             "label": "contract BondingConfig",
             "numberOfBytes": "20"
           },
-          "t_contract(IAgentFactoryV7Minimal)3334": {
+          "t_contract(IAgentFactoryV7Minimal)2297": {
             "label": "contract IAgentFactoryV7Minimal",
             "numberOfBytes": "20"
           },
-          "t_contract(IFFactoryV2Minimal)3207": {
+          "t_contract(IFFactoryV2Minimal)2170": {
             "label": "contract IFFactoryV2Minimal",
             "numberOfBytes": "20"
           },
-          "t_contract(IFRouterV3Minimal)3269": {
+          "t_contract(IFRouterV3Minimal)2232": {
             "label": "contract IFRouterV3Minimal",
             "numberOfBytes": "20"
           },
@@ -31994,11 +31994,11 @@
             "label": "mapping(address => bytes)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_address,t_struct(LaunchParams)2486_storage)": {
+          "t_mapping(t_address,t_struct(LaunchParams)1449_storage)": {
             "label": "mapping(address => struct BondingConfig.LaunchParams)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_address,t_struct(Token)2475_storage)": {
+          "t_mapping(t_address,t_struct(Token)1438_storage)": {
             "label": "mapping(address => struct BondingConfig.Token)",
             "numberOfBytes": "32"
           },
@@ -32010,7 +32010,7 @@
             "label": "string",
             "numberOfBytes": "32"
           },
-          "t_struct(Data)2436_storage": {
+          "t_struct(Data)1399_storage": {
             "label": "struct BondingConfig.Data",
             "members": [
               {
@@ -32088,7 +32088,7 @@
             ],
             "numberOfBytes": "384"
           },
-          "t_struct(LaunchParams)2486_storage": {
+          "t_struct(LaunchParams)1449_storage": {
             "label": "struct BondingConfig.LaunchParams",
             "members": [
               {
@@ -32124,7 +32124,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(Token)2475_storage": {
+          "t_struct(Token)1438_storage": {
             "label": "struct BondingConfig.Token",
             "members": [
               {
@@ -32153,7 +32153,7 @@
               },
               {
                 "label": "data",
-                "type": "t_struct(Data)2436_storage",
+                "type": "t_struct(Data)1399_storage",
                 "offset": 0,
                 "slot": "4"
               },
@@ -32264,6 +32264,778 @@
               "label": "_status",
               "type": "t_uint256",
               "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "4d4ef2d622d9d80c9a7d21b5224290452ee8ae3875b37b60efe2b518531dbcdc": {
+      "address": "0x99cF33b8DB42503A125D02Ba20110f0574686C92",
+      "txHash": "0xe6f37790c699859bc8c0eac9a77c16113e77871cb0711db3dd43cc237ca4437c",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(IFFactoryV2Minimal)2188",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:95"
+          },
+          {
+            "label": "router",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_contract(IFRouterV3Minimal)2250",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:96"
+          },
+          {
+            "label": "agentFactory",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IAgentFactoryV7Minimal)2315",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:97"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(BondingConfig)2150",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:98"
+          },
+          {
+            "label": "tokenInfo",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_struct(Token)1441_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:100"
+          },
+          {
+            "label": "tokenInfos",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:101"
+          },
+          {
+            "label": "tokenLaunchParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_address,t_struct(LaunchParams)1452_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:107"
+          },
+          {
+            "label": "tokenGradThreshold",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:110"
+          },
+          {
+            "label": "isFeeDelegation",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:112"
+          },
+          {
+            "label": "tokenPreLaunchExtParams",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_mapping(t_address,t_bytes_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:115"
+          },
+          {
+            "label": "tokenFakeInitialVirtualLiq",
+            "offset": 0,
+            "slot": "10",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:120"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)158_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint8)dyn_storage": {
+            "label": "uint8[]",
+            "numberOfBytes": "32"
+          },
+          "t_bytes_storage": {
+            "label": "bytes",
+            "numberOfBytes": "32"
+          },
+          "t_contract(BondingConfig)2150": {
+            "label": "contract BondingConfig",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IAgentFactoryV7Minimal)2315": {
+            "label": "contract IAgentFactoryV7Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFFactoryV2Minimal)2188": {
+            "label": "contract IFFactoryV2Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFRouterV3Minimal)2250": {
+            "label": "contract IFRouterV3Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bytes_storage)": {
+            "label": "mapping(address => bytes)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(LaunchParams)1452_storage)": {
+            "label": "mapping(address => struct BondingConfig.LaunchParams)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Token)1441_storage)": {
+            "label": "mapping(address => struct BondingConfig.Token)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Data)1402_storage": {
+            "label": "struct BondingConfig.Data",
+            "members": [
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "ticker",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "supply",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "price",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "marketCap",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "liquidity",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "volume",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "volume24H",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "prevPrice",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "10"
+              },
+              {
+                "label": "lastUpdated",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "11"
+              }
+            ],
+            "numberOfBytes": "384"
+          },
+          "t_struct(LaunchParams)1452_storage": {
+            "label": "struct BondingConfig.LaunchParams",
+            "members": [
+              {
+                "label": "launchMode",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "airdropBips",
+                "type": "t_uint16",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "needAcf",
+                "type": "t_bool",
+                "offset": 3,
+                "slot": "0"
+              },
+              {
+                "label": "antiSniperTaxType",
+                "type": "t_uint8",
+                "offset": 4,
+                "slot": "0"
+              },
+              {
+                "label": "isProject60days",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Token)1441_storage": {
+            "label": "struct BondingConfig.Token",
+            "members": [
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "pair",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "agentToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "data",
+                "type": "t_struct(Data)1402_storage",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "description",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "16"
+              },
+              {
+                "label": "cores",
+                "type": "t_array(t_uint8)dyn_storage",
+                "offset": 0,
+                "slot": "17"
+              },
+              {
+                "label": "image",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "18"
+              },
+              {
+                "label": "twitter",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "19"
+              },
+              {
+                "label": "telegram",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "20"
+              },
+              {
+                "label": "youtube",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "21"
+              },
+              {
+                "label": "website",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "22"
+              },
+              {
+                "label": "trading",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "23"
+              },
+              {
+                "label": "tradingOnUniswap",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "23"
+              },
+              {
+                "label": "applicationId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "24"
+              },
+              {
+                "label": "initialPurchase",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "25"
+              },
+              {
+                "label": "virtualId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "26"
+              },
+              {
+                "label": "launchExecuted",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "27"
+              }
+            ],
+            "numberOfBytes": "896"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "bf421ce14be84cdf10bcc11697529a43d61b7c06b3fc26d41dc441563094b5d9": {
+      "address": "0xBe0a0675D2D75C5D0b4eC597812Ef1B3c962214c",
+      "txHash": "0x1f652f9c1d18784545226fa9e93ea6adcb879e62557059a0fc26440a309338ec",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "reserveSupplyParams",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_struct(ReserveSupplyParams)1331_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:26"
+          },
+          {
+            "label": "scheduledLaunchParams",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_struct(ScheduledLaunchParams)1359_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:44"
+          },
+          {
+            "label": "teamTokenReservedWallet",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:47"
+          },
+          {
+            "label": "isPrivilegedLauncher",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:50"
+          },
+          {
+            "label": "bondingCurveParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_struct(BondingCurveParams)1374_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:57"
+          },
+          {
+            "label": "deployParams",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_struct(DeployParams)1461_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:112"
+          },
+          {
+            "label": "initialSupply",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:115"
+          },
+          {
+            "label": "feeTo",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:116"
+          },
+          {
+            "label": "acfFakeInitialVirtualLiq",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:121"
+          },
+          {
+            "label": "graduationExcessBurnWallet",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:124"
+          },
+          {
+            "label": "legacyInitialVirtualLiq",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BondingCurveParams)1374_storage": {
+            "label": "struct BondingConfig.BondingCurveParams",
+            "members": [
+              {
+                "label": "fakeInitialVirtualLiq",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "targetRealVirtual",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(DeployParams)1461_storage": {
+            "label": "struct BondingConfig.DeployParams",
+            "members": [
+              {
+                "label": "tbaSalt",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tbaImplementation",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "daoVotingPeriod",
+                "type": "t_uint32",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "daoThreshold",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(ReserveSupplyParams)1331_storage": {
+            "label": "struct BondingConfig.ReserveSupplyParams",
+            "members": [
+              {
+                "label": "maxAirdropBips",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "maxTotalReservedBips",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              },
+              {
+                "label": "acfReservedBips",
+                "type": "t_uint16",
+                "offset": 4,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ScheduledLaunchParams)1359_storage": {
+            "label": "struct BondingConfig.ScheduledLaunchParams",
+            "members": [
+              {
+                "label": "startTimeDelay",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "normalLaunchFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "acfFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
               "offset": 0,
               "slot": "0"
             }

--- a/.openzeppelin/unknown-4663.json
+++ b/.openzeppelin/unknown-4663.json
@@ -2596,7 +2596,7 @@
             "label": "reserveSupplyParams",
             "offset": 0,
             "slot": "0",
-            "type": "t_struct(ReserveSupplyParams)2368_storage",
+            "type": "t_struct(ReserveSupplyParams)1331_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:26"
           },
@@ -2604,7 +2604,7 @@
             "label": "scheduledLaunchParams",
             "offset": 0,
             "slot": "1",
-            "type": "t_struct(ScheduledLaunchParams)2393_storage",
+            "type": "t_struct(ScheduledLaunchParams)1356_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:43"
           },
@@ -2628,7 +2628,7 @@
             "label": "bondingCurveParams",
             "offset": 0,
             "slot": "6",
-            "type": "t_struct(BondingCurveParams)2408_storage",
+            "type": "t_struct(BondingCurveParams)1371_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:56"
           },
@@ -2636,7 +2636,7 @@
             "label": "deployParams",
             "offset": 0,
             "slot": "8",
-            "type": "t_struct(DeployParams)2495_storage",
+            "type": "t_struct(DeployParams)1458_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:111"
           },
@@ -2690,7 +2690,7 @@
             "label": "bool",
             "numberOfBytes": "1"
           },
-          "t_struct(InitializableStorage)211_storage": {
+          "t_struct(InitializableStorage)73_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -2708,7 +2708,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(OwnableStorage)151_storage": {
+          "t_struct(OwnableStorage)13_storage": {
             "label": "struct OwnableUpgradeable.OwnableStorage",
             "members": [
               {
@@ -2732,7 +2732,7 @@
             "label": "mapping(address => bool)",
             "numberOfBytes": "32"
           },
-          "t_struct(BondingCurveParams)2408_storage": {
+          "t_struct(BondingCurveParams)1371_storage": {
             "label": "struct BondingConfig.BondingCurveParams",
             "members": [
               {
@@ -2750,7 +2750,7 @@
             ],
             "numberOfBytes": "64"
           },
-          "t_struct(DeployParams)2495_storage": {
+          "t_struct(DeployParams)1458_storage": {
             "label": "struct BondingConfig.DeployParams",
             "members": [
               {
@@ -2780,7 +2780,7 @@
             ],
             "numberOfBytes": "96"
           },
-          "t_struct(ReserveSupplyParams)2368_storage": {
+          "t_struct(ReserveSupplyParams)1331_storage": {
             "label": "struct BondingConfig.ReserveSupplyParams",
             "members": [
               {
@@ -2804,7 +2804,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(ScheduledLaunchParams)2393_storage": {
+          "t_struct(ScheduledLaunchParams)1356_storage": {
             "label": "struct BondingConfig.ScheduledLaunchParams",
             "members": [
               {
@@ -3066,7 +3066,7 @@
             "label": "factory",
             "offset": 0,
             "slot": "0",
-            "type": "t_contract(IFFactoryV2Minimal)3207",
+            "type": "t_contract(IFFactoryV2Minimal)2170",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:95"
           },
@@ -3074,7 +3074,7 @@
             "label": "router",
             "offset": 0,
             "slot": "1",
-            "type": "t_contract(IFRouterV3Minimal)3269",
+            "type": "t_contract(IFRouterV3Minimal)2232",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:96"
           },
@@ -3082,7 +3082,7 @@
             "label": "agentFactory",
             "offset": 0,
             "slot": "2",
-            "type": "t_contract(IAgentFactoryV7Minimal)3334",
+            "type": "t_contract(IAgentFactoryV7Minimal)2297",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:97"
           },
@@ -3090,7 +3090,7 @@
             "label": "bondingConfig",
             "offset": 0,
             "slot": "3",
-            "type": "t_contract(BondingConfig)3169",
+            "type": "t_contract(BondingConfig)2132",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:98"
           },
@@ -3098,7 +3098,7 @@
             "label": "tokenInfo",
             "offset": 0,
             "slot": "4",
-            "type": "t_mapping(t_address,t_struct(Token)2475_storage)",
+            "type": "t_mapping(t_address,t_struct(Token)1438_storage)",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:100"
           },
@@ -3114,7 +3114,7 @@
             "label": "tokenLaunchParams",
             "offset": 0,
             "slot": "6",
-            "type": "t_mapping(t_address,t_struct(LaunchParams)2486_storage)",
+            "type": "t_mapping(t_address,t_struct(LaunchParams)1449_storage)",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:107"
           },
@@ -3160,7 +3160,7 @@
             "label": "bool",
             "numberOfBytes": "1"
           },
-          "t_struct(InitializableStorage)211_storage": {
+          "t_struct(InitializableStorage)73_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -3178,7 +3178,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(OwnableStorage)151_storage": {
+          "t_struct(OwnableStorage)13_storage": {
             "label": "struct OwnableUpgradeable.OwnableStorage",
             "members": [
               {
@@ -3190,7 +3190,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(ReentrancyGuardStorage)296_storage": {
+          "t_struct(ReentrancyGuardStorage)158_storage": {
             "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
             "members": [
               {
@@ -3222,19 +3222,19 @@
             "label": "bytes",
             "numberOfBytes": "32"
           },
-          "t_contract(BondingConfig)3169": {
+          "t_contract(BondingConfig)2132": {
             "label": "contract BondingConfig",
             "numberOfBytes": "20"
           },
-          "t_contract(IAgentFactoryV7Minimal)3334": {
+          "t_contract(IAgentFactoryV7Minimal)2297": {
             "label": "contract IAgentFactoryV7Minimal",
             "numberOfBytes": "20"
           },
-          "t_contract(IFFactoryV2Minimal)3207": {
+          "t_contract(IFFactoryV2Minimal)2170": {
             "label": "contract IFFactoryV2Minimal",
             "numberOfBytes": "20"
           },
-          "t_contract(IFRouterV3Minimal)3269": {
+          "t_contract(IFRouterV3Minimal)2232": {
             "label": "contract IFRouterV3Minimal",
             "numberOfBytes": "20"
           },
@@ -3246,11 +3246,11 @@
             "label": "mapping(address => bytes)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_address,t_struct(LaunchParams)2486_storage)": {
+          "t_mapping(t_address,t_struct(LaunchParams)1449_storage)": {
             "label": "mapping(address => struct BondingConfig.LaunchParams)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_address,t_struct(Token)2475_storage)": {
+          "t_mapping(t_address,t_struct(Token)1438_storage)": {
             "label": "mapping(address => struct BondingConfig.Token)",
             "numberOfBytes": "32"
           },
@@ -3262,7 +3262,7 @@
             "label": "string",
             "numberOfBytes": "32"
           },
-          "t_struct(Data)2436_storage": {
+          "t_struct(Data)1399_storage": {
             "label": "struct BondingConfig.Data",
             "members": [
               {
@@ -3340,7 +3340,7 @@
             ],
             "numberOfBytes": "384"
           },
-          "t_struct(LaunchParams)2486_storage": {
+          "t_struct(LaunchParams)1449_storage": {
             "label": "struct BondingConfig.LaunchParams",
             "members": [
               {
@@ -3376,7 +3376,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(Token)2475_storage": {
+          "t_struct(Token)1438_storage": {
             "label": "struct BondingConfig.Token",
             "members": [
               {
@@ -3405,7 +3405,7 @@
               },
               {
                 "label": "data",
-                "type": "t_struct(Data)2436_storage",
+                "type": "t_struct(Data)1399_storage",
                 "offset": 0,
                 "slot": "4"
               },
@@ -3516,6 +3516,778 @@
               "label": "_status",
               "type": "t_uint256",
               "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "4d4ef2d622d9d80c9a7d21b5224290452ee8ae3875b37b60efe2b518531dbcdc": {
+      "address": "0x319Dd22FEBD8AB7370761b59fBAEa1f00c80B970",
+      "txHash": "0xc2eca2893791b36675200a985c7bfbc51dbfaad1cf2389a4a63da70f99dc8410",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(IFFactoryV2Minimal)2188",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:95"
+          },
+          {
+            "label": "router",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_contract(IFRouterV3Minimal)2250",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:96"
+          },
+          {
+            "label": "agentFactory",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IAgentFactoryV7Minimal)2315",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:97"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(BondingConfig)2150",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:98"
+          },
+          {
+            "label": "tokenInfo",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_struct(Token)1441_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:100"
+          },
+          {
+            "label": "tokenInfos",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:101"
+          },
+          {
+            "label": "tokenLaunchParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_address,t_struct(LaunchParams)1452_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:107"
+          },
+          {
+            "label": "tokenGradThreshold",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:110"
+          },
+          {
+            "label": "isFeeDelegation",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:112"
+          },
+          {
+            "label": "tokenPreLaunchExtParams",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_mapping(t_address,t_bytes_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:115"
+          },
+          {
+            "label": "tokenFakeInitialVirtualLiq",
+            "offset": 0,
+            "slot": "10",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:120"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)158_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint8)dyn_storage": {
+            "label": "uint8[]",
+            "numberOfBytes": "32"
+          },
+          "t_bytes_storage": {
+            "label": "bytes",
+            "numberOfBytes": "32"
+          },
+          "t_contract(BondingConfig)2150": {
+            "label": "contract BondingConfig",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IAgentFactoryV7Minimal)2315": {
+            "label": "contract IAgentFactoryV7Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFFactoryV2Minimal)2188": {
+            "label": "contract IFFactoryV2Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFRouterV3Minimal)2250": {
+            "label": "contract IFRouterV3Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bytes_storage)": {
+            "label": "mapping(address => bytes)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(LaunchParams)1452_storage)": {
+            "label": "mapping(address => struct BondingConfig.LaunchParams)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Token)1441_storage)": {
+            "label": "mapping(address => struct BondingConfig.Token)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Data)1402_storage": {
+            "label": "struct BondingConfig.Data",
+            "members": [
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "ticker",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "supply",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "price",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "marketCap",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "liquidity",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "volume",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "volume24H",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "prevPrice",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "10"
+              },
+              {
+                "label": "lastUpdated",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "11"
+              }
+            ],
+            "numberOfBytes": "384"
+          },
+          "t_struct(LaunchParams)1452_storage": {
+            "label": "struct BondingConfig.LaunchParams",
+            "members": [
+              {
+                "label": "launchMode",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "airdropBips",
+                "type": "t_uint16",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "needAcf",
+                "type": "t_bool",
+                "offset": 3,
+                "slot": "0"
+              },
+              {
+                "label": "antiSniperTaxType",
+                "type": "t_uint8",
+                "offset": 4,
+                "slot": "0"
+              },
+              {
+                "label": "isProject60days",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Token)1441_storage": {
+            "label": "struct BondingConfig.Token",
+            "members": [
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "pair",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "agentToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "data",
+                "type": "t_struct(Data)1402_storage",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "description",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "16"
+              },
+              {
+                "label": "cores",
+                "type": "t_array(t_uint8)dyn_storage",
+                "offset": 0,
+                "slot": "17"
+              },
+              {
+                "label": "image",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "18"
+              },
+              {
+                "label": "twitter",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "19"
+              },
+              {
+                "label": "telegram",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "20"
+              },
+              {
+                "label": "youtube",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "21"
+              },
+              {
+                "label": "website",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "22"
+              },
+              {
+                "label": "trading",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "23"
+              },
+              {
+                "label": "tradingOnUniswap",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "23"
+              },
+              {
+                "label": "applicationId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "24"
+              },
+              {
+                "label": "initialPurchase",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "25"
+              },
+              {
+                "label": "virtualId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "26"
+              },
+              {
+                "label": "launchExecuted",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "27"
+              }
+            ],
+            "numberOfBytes": "896"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "bf421ce14be84cdf10bcc11697529a43d61b7c06b3fc26d41dc441563094b5d9": {
+      "address": "0x13C4A51590DA706aA01654dF25e80e7d001728C6",
+      "txHash": "0xc6288c7ba0cd61b69c3b2872fc86ccc689d90e0a12d8267fe15420e70fc6c16c",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "reserveSupplyParams",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_struct(ReserveSupplyParams)1331_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:26"
+          },
+          {
+            "label": "scheduledLaunchParams",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_struct(ScheduledLaunchParams)1359_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:44"
+          },
+          {
+            "label": "teamTokenReservedWallet",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:47"
+          },
+          {
+            "label": "isPrivilegedLauncher",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:50"
+          },
+          {
+            "label": "bondingCurveParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_struct(BondingCurveParams)1374_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:57"
+          },
+          {
+            "label": "deployParams",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_struct(DeployParams)1461_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:112"
+          },
+          {
+            "label": "initialSupply",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:115"
+          },
+          {
+            "label": "feeTo",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:116"
+          },
+          {
+            "label": "acfFakeInitialVirtualLiq",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:121"
+          },
+          {
+            "label": "graduationExcessBurnWallet",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:124"
+          },
+          {
+            "label": "legacyInitialVirtualLiq",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BondingCurveParams)1374_storage": {
+            "label": "struct BondingConfig.BondingCurveParams",
+            "members": [
+              {
+                "label": "fakeInitialVirtualLiq",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "targetRealVirtual",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(DeployParams)1461_storage": {
+            "label": "struct BondingConfig.DeployParams",
+            "members": [
+              {
+                "label": "tbaSalt",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tbaImplementation",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "daoVotingPeriod",
+                "type": "t_uint32",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "daoThreshold",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(ReserveSupplyParams)1331_storage": {
+            "label": "struct BondingConfig.ReserveSupplyParams",
+            "members": [
+              {
+                "label": "maxAirdropBips",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "maxTotalReservedBips",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              },
+              {
+                "label": "acfReservedBips",
+                "type": "t_uint16",
+                "offset": 4,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ScheduledLaunchParams)1359_storage": {
+            "label": "struct BondingConfig.ScheduledLaunchParams",
+            "members": [
+              {
+                "label": "startTimeDelay",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "normalLaunchFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "acfFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
               "offset": 0,
               "slot": "0"
             }

--- a/.openzeppelin/unknown-46630.json
+++ b/.openzeppelin/unknown-46630.json
@@ -2564,7 +2564,7 @@
             "label": "reserveSupplyParams",
             "offset": 0,
             "slot": "0",
-            "type": "t_struct(ReserveSupplyParams)2368_storage",
+            "type": "t_struct(ReserveSupplyParams)1331_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:26"
           },
@@ -2572,7 +2572,7 @@
             "label": "scheduledLaunchParams",
             "offset": 0,
             "slot": "1",
-            "type": "t_struct(ScheduledLaunchParams)2393_storage",
+            "type": "t_struct(ScheduledLaunchParams)1356_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:43"
           },
@@ -2596,7 +2596,7 @@
             "label": "bondingCurveParams",
             "offset": 0,
             "slot": "6",
-            "type": "t_struct(BondingCurveParams)2408_storage",
+            "type": "t_struct(BondingCurveParams)1371_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:56"
           },
@@ -2604,7 +2604,7 @@
             "label": "deployParams",
             "offset": 0,
             "slot": "8",
-            "type": "t_struct(DeployParams)2495_storage",
+            "type": "t_struct(DeployParams)1458_storage",
             "contract": "BondingConfig",
             "src": "contracts/launchpadv2/BondingConfig.sol:111"
           },
@@ -2658,7 +2658,7 @@
             "label": "bool",
             "numberOfBytes": "1"
           },
-          "t_struct(InitializableStorage)211_storage": {
+          "t_struct(InitializableStorage)73_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -2676,7 +2676,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(OwnableStorage)151_storage": {
+          "t_struct(OwnableStorage)13_storage": {
             "label": "struct OwnableUpgradeable.OwnableStorage",
             "members": [
               {
@@ -2700,7 +2700,7 @@
             "label": "mapping(address => bool)",
             "numberOfBytes": "32"
           },
-          "t_struct(BondingCurveParams)2408_storage": {
+          "t_struct(BondingCurveParams)1371_storage": {
             "label": "struct BondingConfig.BondingCurveParams",
             "members": [
               {
@@ -2718,7 +2718,7 @@
             ],
             "numberOfBytes": "64"
           },
-          "t_struct(DeployParams)2495_storage": {
+          "t_struct(DeployParams)1458_storage": {
             "label": "struct BondingConfig.DeployParams",
             "members": [
               {
@@ -2748,7 +2748,7 @@
             ],
             "numberOfBytes": "96"
           },
-          "t_struct(ReserveSupplyParams)2368_storage": {
+          "t_struct(ReserveSupplyParams)1331_storage": {
             "label": "struct BondingConfig.ReserveSupplyParams",
             "members": [
               {
@@ -2772,7 +2772,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(ScheduledLaunchParams)2393_storage": {
+          "t_struct(ScheduledLaunchParams)1356_storage": {
             "label": "struct BondingConfig.ScheduledLaunchParams",
             "members": [
               {
@@ -3034,7 +3034,7 @@
             "label": "factory",
             "offset": 0,
             "slot": "0",
-            "type": "t_contract(IFFactoryV2Minimal)3207",
+            "type": "t_contract(IFFactoryV2Minimal)2170",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:95"
           },
@@ -3042,7 +3042,7 @@
             "label": "router",
             "offset": 0,
             "slot": "1",
-            "type": "t_contract(IFRouterV3Minimal)3269",
+            "type": "t_contract(IFRouterV3Minimal)2232",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:96"
           },
@@ -3050,7 +3050,7 @@
             "label": "agentFactory",
             "offset": 0,
             "slot": "2",
-            "type": "t_contract(IAgentFactoryV7Minimal)3334",
+            "type": "t_contract(IAgentFactoryV7Minimal)2297",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:97"
           },
@@ -3058,7 +3058,7 @@
             "label": "bondingConfig",
             "offset": 0,
             "slot": "3",
-            "type": "t_contract(BondingConfig)3169",
+            "type": "t_contract(BondingConfig)2132",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:98"
           },
@@ -3066,7 +3066,7 @@
             "label": "tokenInfo",
             "offset": 0,
             "slot": "4",
-            "type": "t_mapping(t_address,t_struct(Token)2475_storage)",
+            "type": "t_mapping(t_address,t_struct(Token)1438_storage)",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:100"
           },
@@ -3082,7 +3082,7 @@
             "label": "tokenLaunchParams",
             "offset": 0,
             "slot": "6",
-            "type": "t_mapping(t_address,t_struct(LaunchParams)2486_storage)",
+            "type": "t_mapping(t_address,t_struct(LaunchParams)1449_storage)",
             "contract": "BondingV5",
             "src": "contracts/launchpadv2/BondingV5.sol:107"
           },
@@ -3128,7 +3128,7 @@
             "label": "bool",
             "numberOfBytes": "1"
           },
-          "t_struct(InitializableStorage)211_storage": {
+          "t_struct(InitializableStorage)73_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -3146,7 +3146,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(OwnableStorage)151_storage": {
+          "t_struct(OwnableStorage)13_storage": {
             "label": "struct OwnableUpgradeable.OwnableStorage",
             "members": [
               {
@@ -3158,7 +3158,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(ReentrancyGuardStorage)296_storage": {
+          "t_struct(ReentrancyGuardStorage)158_storage": {
             "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
             "members": [
               {
@@ -3190,19 +3190,19 @@
             "label": "bytes",
             "numberOfBytes": "32"
           },
-          "t_contract(BondingConfig)3169": {
+          "t_contract(BondingConfig)2132": {
             "label": "contract BondingConfig",
             "numberOfBytes": "20"
           },
-          "t_contract(IAgentFactoryV7Minimal)3334": {
+          "t_contract(IAgentFactoryV7Minimal)2297": {
             "label": "contract IAgentFactoryV7Minimal",
             "numberOfBytes": "20"
           },
-          "t_contract(IFFactoryV2Minimal)3207": {
+          "t_contract(IFFactoryV2Minimal)2170": {
             "label": "contract IFFactoryV2Minimal",
             "numberOfBytes": "20"
           },
-          "t_contract(IFRouterV3Minimal)3269": {
+          "t_contract(IFRouterV3Minimal)2232": {
             "label": "contract IFRouterV3Minimal",
             "numberOfBytes": "20"
           },
@@ -3214,11 +3214,11 @@
             "label": "mapping(address => bytes)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_address,t_struct(LaunchParams)2486_storage)": {
+          "t_mapping(t_address,t_struct(LaunchParams)1449_storage)": {
             "label": "mapping(address => struct BondingConfig.LaunchParams)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_address,t_struct(Token)2475_storage)": {
+          "t_mapping(t_address,t_struct(Token)1438_storage)": {
             "label": "mapping(address => struct BondingConfig.Token)",
             "numberOfBytes": "32"
           },
@@ -3230,7 +3230,7 @@
             "label": "string",
             "numberOfBytes": "32"
           },
-          "t_struct(Data)2436_storage": {
+          "t_struct(Data)1399_storage": {
             "label": "struct BondingConfig.Data",
             "members": [
               {
@@ -3308,7 +3308,7 @@
             ],
             "numberOfBytes": "384"
           },
-          "t_struct(LaunchParams)2486_storage": {
+          "t_struct(LaunchParams)1449_storage": {
             "label": "struct BondingConfig.LaunchParams",
             "members": [
               {
@@ -3344,7 +3344,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(Token)2475_storage": {
+          "t_struct(Token)1438_storage": {
             "label": "struct BondingConfig.Token",
             "members": [
               {
@@ -3373,7 +3373,7 @@
               },
               {
                 "label": "data",
-                "type": "t_struct(Data)2436_storage",
+                "type": "t_struct(Data)1399_storage",
                 "offset": 0,
                 "slot": "4"
               },
@@ -3484,6 +3484,778 @@
               "label": "_status",
               "type": "t_uint256",
               "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "4d4ef2d622d9d80c9a7d21b5224290452ee8ae3875b37b60efe2b518531dbcdc": {
+      "address": "0x15C99296D0a5E1bAe28683A494C1B655D5399e54",
+      "txHash": "0xb37df4f0528fc1633faa8ab2269e6dcffcae3a1a3676119eda6e9193dc940b8a",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(IFFactoryV2Minimal)2188",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:95"
+          },
+          {
+            "label": "router",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_contract(IFRouterV3Minimal)2250",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:96"
+          },
+          {
+            "label": "agentFactory",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IAgentFactoryV7Minimal)2315",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:97"
+          },
+          {
+            "label": "bondingConfig",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(BondingConfig)2150",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:98"
+          },
+          {
+            "label": "tokenInfo",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_struct(Token)1441_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:100"
+          },
+          {
+            "label": "tokenInfos",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:101"
+          },
+          {
+            "label": "tokenLaunchParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_address,t_struct(LaunchParams)1452_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:107"
+          },
+          {
+            "label": "tokenGradThreshold",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:110"
+          },
+          {
+            "label": "isFeeDelegation",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:112"
+          },
+          {
+            "label": "tokenPreLaunchExtParams",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_mapping(t_address,t_bytes_storage)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:115"
+          },
+          {
+            "label": "tokenFakeInitialVirtualLiq",
+            "offset": 0,
+            "slot": "10",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "BondingV5",
+            "src": "contracts/launchpadv2/BondingV5.sol:120"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)158_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint8)dyn_storage": {
+            "label": "uint8[]",
+            "numberOfBytes": "32"
+          },
+          "t_bytes_storage": {
+            "label": "bytes",
+            "numberOfBytes": "32"
+          },
+          "t_contract(BondingConfig)2150": {
+            "label": "contract BondingConfig",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IAgentFactoryV7Minimal)2315": {
+            "label": "contract IAgentFactoryV7Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFFactoryV2Minimal)2188": {
+            "label": "contract IFFactoryV2Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFRouterV3Minimal)2250": {
+            "label": "contract IFRouterV3Minimal",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bytes_storage)": {
+            "label": "mapping(address => bytes)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(LaunchParams)1452_storage)": {
+            "label": "mapping(address => struct BondingConfig.LaunchParams)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Token)1441_storage)": {
+            "label": "mapping(address => struct BondingConfig.Token)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Data)1402_storage": {
+            "label": "struct BondingConfig.Data",
+            "members": [
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "ticker",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "supply",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "price",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "marketCap",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "liquidity",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "volume",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "volume24H",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "prevPrice",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "10"
+              },
+              {
+                "label": "lastUpdated",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "11"
+              }
+            ],
+            "numberOfBytes": "384"
+          },
+          "t_struct(LaunchParams)1452_storage": {
+            "label": "struct BondingConfig.LaunchParams",
+            "members": [
+              {
+                "label": "launchMode",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "airdropBips",
+                "type": "t_uint16",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "needAcf",
+                "type": "t_bool",
+                "offset": 3,
+                "slot": "0"
+              },
+              {
+                "label": "antiSniperTaxType",
+                "type": "t_uint8",
+                "offset": 4,
+                "slot": "0"
+              },
+              {
+                "label": "isProject60days",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Token)1441_storage": {
+            "label": "struct BondingConfig.Token",
+            "members": [
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "pair",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "agentToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "data",
+                "type": "t_struct(Data)1402_storage",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "description",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "16"
+              },
+              {
+                "label": "cores",
+                "type": "t_array(t_uint8)dyn_storage",
+                "offset": 0,
+                "slot": "17"
+              },
+              {
+                "label": "image",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "18"
+              },
+              {
+                "label": "twitter",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "19"
+              },
+              {
+                "label": "telegram",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "20"
+              },
+              {
+                "label": "youtube",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "21"
+              },
+              {
+                "label": "website",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "22"
+              },
+              {
+                "label": "trading",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "23"
+              },
+              {
+                "label": "tradingOnUniswap",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "23"
+              },
+              {
+                "label": "applicationId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "24"
+              },
+              {
+                "label": "initialPurchase",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "25"
+              },
+              {
+                "label": "virtualId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "26"
+              },
+              {
+                "label": "launchExecuted",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "27"
+              }
+            ],
+            "numberOfBytes": "896"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "bf421ce14be84cdf10bcc11697529a43d61b7c06b3fc26d41dc441563094b5d9": {
+      "address": "0x0Da175f7bA11efB691F9c56C2839221c6E5c36F3",
+      "txHash": "0x27a93cbf1fe42fa46f13dc4bab668296ff0305dba08785d834d0c114b945bc23",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "reserveSupplyParams",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_struct(ReserveSupplyParams)1331_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:26"
+          },
+          {
+            "label": "scheduledLaunchParams",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_struct(ScheduledLaunchParams)1359_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:44"
+          },
+          {
+            "label": "teamTokenReservedWallet",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:47"
+          },
+          {
+            "label": "isPrivilegedLauncher",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:50"
+          },
+          {
+            "label": "bondingCurveParams",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_struct(BondingCurveParams)1374_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:57"
+          },
+          {
+            "label": "deployParams",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_struct(DeployParams)1461_storage",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:112"
+          },
+          {
+            "label": "initialSupply",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:115"
+          },
+          {
+            "label": "feeTo",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:116"
+          },
+          {
+            "label": "acfFakeInitialVirtualLiq",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:121"
+          },
+          {
+            "label": "graduationExcessBurnWallet",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_address",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:124"
+          },
+          {
+            "label": "legacyInitialVirtualLiq",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_uint256",
+            "contract": "BondingConfig",
+            "src": "contracts/launchpadv2/BondingConfig.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BondingCurveParams)1374_storage": {
+            "label": "struct BondingConfig.BondingCurveParams",
+            "members": [
+              {
+                "label": "fakeInitialVirtualLiq",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "targetRealVirtual",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(DeployParams)1461_storage": {
+            "label": "struct BondingConfig.DeployParams",
+            "members": [
+              {
+                "label": "tbaSalt",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tbaImplementation",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "daoVotingPeriod",
+                "type": "t_uint32",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "daoThreshold",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(ReserveSupplyParams)1331_storage": {
+            "label": "struct BondingConfig.ReserveSupplyParams",
+            "members": [
+              {
+                "label": "maxAirdropBips",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "maxTotalReservedBips",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              },
+              {
+                "label": "acfReservedBips",
+                "type": "t_uint16",
+                "offset": 4,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ScheduledLaunchParams)1359_storage": {
+            "label": "struct BondingConfig.ScheduledLaunchParams",
+            "members": [
+              {
+                "label": "startTimeDelay",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "normalLaunchFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "acfFee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
               "offset": 0,
               "slot": "0"
             }

--- a/contracts/launchpadv2/BondingConfig.sol
+++ b/contracts/launchpadv2/BondingConfig.sol
@@ -32,7 +32,7 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
     uint8 public constant ANTI_SNIPER_98M = 2; // 98 minutes buy-only
     uint8 public constant ANTI_SNIPER_98M_SELL = 3; // 98 minutes sell-only
     uint8 public constant ANTI_SNIPER_98M_BOTH = 4; // 98 minutes buy and sell
-    uint8 public constant ANTI_SNIPER_8M = 5; // 8 minutes buy-only
+    uint8 public constant ANTI_SNIPER_10M = 5; // 10 minutes buy-only
 
     // Scheduled launch parameters
     struct ScheduledLaunchParams {
@@ -365,7 +365,7 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
 
     /**
      * @notice Check if anti-sniper tax type is valid
-     * @param antiSniperType_ 0=none, 1=60s buy, 2=98m buy, 3=98m sell, 4=98m both, 5=8m buy
+     * @param antiSniperType_ 0=none, 1=60s buy, 2=98m buy, 3=98m sell, 4=98m both, 5=10m buy
      * @return Whether the type is valid
      */
     function isValidAntiSniperType(
@@ -377,7 +377,7 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
             antiSniperType_ == ANTI_SNIPER_98M ||
             antiSniperType_ == ANTI_SNIPER_98M_SELL ||
             antiSniperType_ == ANTI_SNIPER_98M_BOTH ||
-            antiSniperType_ == ANTI_SNIPER_8M;
+            antiSniperType_ == ANTI_SNIPER_10M;
     }
 
     /**
@@ -390,7 +390,7 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
             antiSniperType_ == ANTI_SNIPER_60S ||
             antiSniperType_ == ANTI_SNIPER_98M ||
             antiSniperType_ == ANTI_SNIPER_98M_BOTH ||
-            antiSniperType_ == ANTI_SNIPER_8M;
+            antiSniperType_ == ANTI_SNIPER_10M;
     }
 
     /**
@@ -407,7 +407,7 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
     /**
      * @notice Get anti-sniper tax duration in seconds for a given type
      * @param antiSniperType_ The anti-sniper type
-     * @return Duration in seconds (0 for NONE, 60 for 60S, 480 for 8M, 5880 for 98M variants)
+     * @return Duration in seconds (0 for NONE, 60 for 60S, 600 for 10M, 5880 for 98M variants)
      */
     function getAntiSniperDuration(
         uint8 antiSniperType_
@@ -416,8 +416,8 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
             return 0;
         } else if (antiSniperType_ == ANTI_SNIPER_60S) {
             return 60; // 60 seconds
-        } else if (antiSniperType_ == ANTI_SNIPER_8M) {
-            return 480; // 8 minutes = 8 * 60 = 480 seconds
+        } else if (antiSniperType_ == ANTI_SNIPER_10M) {
+            return 600; // 10 minutes = 10 * 60 = 600 seconds
         } else if (
             antiSniperType_ == ANTI_SNIPER_98M ||
             antiSniperType_ == ANTI_SNIPER_98M_SELL ||

--- a/contracts/launchpadv2/BondingConfig.sol
+++ b/contracts/launchpadv2/BondingConfig.sol
@@ -32,6 +32,7 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
     uint8 public constant ANTI_SNIPER_98M = 2; // 98 minutes buy-only
     uint8 public constant ANTI_SNIPER_98M_SELL = 3; // 98 minutes sell-only
     uint8 public constant ANTI_SNIPER_98M_BOTH = 4; // 98 minutes buy and sell
+    uint8 public constant ANTI_SNIPER_8M = 5; // 8 minutes buy-only
 
     // Scheduled launch parameters
     struct ScheduledLaunchParams {
@@ -364,7 +365,7 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
 
     /**
      * @notice Check if anti-sniper tax type is valid
-     * @param antiSniperType_ 0=none, 1=60s buy, 2=98m buy, 3=98m sell, 4=98m both
+     * @param antiSniperType_ 0=none, 1=60s buy, 2=98m buy, 3=98m sell, 4=98m both, 5=8m buy
      * @return Whether the type is valid
      */
     function isValidAntiSniperType(
@@ -375,7 +376,8 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
             antiSniperType_ == ANTI_SNIPER_60S ||
             antiSniperType_ == ANTI_SNIPER_98M ||
             antiSniperType_ == ANTI_SNIPER_98M_SELL ||
-            antiSniperType_ == ANTI_SNIPER_98M_BOTH;
+            antiSniperType_ == ANTI_SNIPER_98M_BOTH ||
+            antiSniperType_ == ANTI_SNIPER_8M;
     }
 
     /**
@@ -387,7 +389,8 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
         return
             antiSniperType_ == ANTI_SNIPER_60S ||
             antiSniperType_ == ANTI_SNIPER_98M ||
-            antiSniperType_ == ANTI_SNIPER_98M_BOTH;
+            antiSniperType_ == ANTI_SNIPER_98M_BOTH ||
+            antiSniperType_ == ANTI_SNIPER_8M;
     }
 
     /**
@@ -404,7 +407,7 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
     /**
      * @notice Get anti-sniper tax duration in seconds for a given type
      * @param antiSniperType_ The anti-sniper type
-     * @return Duration in seconds (0 for NONE, 60 for 60S, 5880 for 98M variants)
+     * @return Duration in seconds (0 for NONE, 60 for 60S, 480 for 8M, 5880 for 98M variants)
      */
     function getAntiSniperDuration(
         uint8 antiSniperType_
@@ -413,6 +416,8 @@ contract BondingConfig is Initializable, OwnableUpgradeable {
             return 0;
         } else if (antiSniperType_ == ANTI_SNIPER_60S) {
             return 60; // 60 seconds
+        } else if (antiSniperType_ == ANTI_SNIPER_8M) {
+            return 480; // 8 minutes = 8 * 60 = 480 seconds
         } else if (
             antiSniperType_ == ANTI_SNIPER_98M ||
             antiSniperType_ == ANTI_SNIPER_98M_SELL ||

--- a/contracts/launchpadv2/BondingV5.sol
+++ b/contracts/launchpadv2/BondingV5.sol
@@ -157,23 +157,34 @@ contract BondingV5 is
         _disableInitializers();
     }
 
-    /// @notice Decode `isFeeDelegation` from optional extension calldata.
-    /// @dev V1 layout: first 32 bytes = `abi.encode(bool isFeeDelegation)` (standard ABI word).
-    ///      Empty `extParams` or length less than 32 ⇒ false. Extra trailing bytes are ignored here so
-    ///      callers can forward-compat append more values after the bool (same encoding rules).
-    ///      Non-canonical bool words (not 0 or 1) ⇒ false.
-    function _decodeIsFeeDelegation(bytes calldata extParams) internal pure returns (bool) {
+    /// @dev `extParams` first 32-byte word — flags in the LSB (same byte as `abi.encode(bool)`):
+    ///      bit 0: `isFeeDelegation`
+    ///      bit 1: skip `" by Virtuals"` suffix (unset ⇒ append; V1-compatible)
+    ///      Empty `extParams` or length < 32 ⇒ both flags false ⇒ fee delegation off, suffix on.
+    uint256 private constant EXT_PARAMS_FLAG_FEE_DELEGATION = 1;
+    uint256 private constant EXT_PARAMS_FLAG_SKIP_SUFFIX = 2;
+
+    function _loadExtParamsWord(
+        bytes calldata extParams
+    ) internal pure returns (uint256 v) {
         if (extParams.length < 32) {
-            return false;
+            return 0;
         }
-        bytes32 word;
         assembly ("memory-safe") {
-            word := calldataload(extParams.offset)
+            v := calldataload(extParams.offset)
         }
-        uint256 v = uint256(word);
-        if (v == 1) return true;
-        if (v == 0) return false;
-        return false;
+    }
+
+    function _decodeIsFeeDelegation(
+        bytes calldata extParams
+    ) internal pure returns (bool) {
+        return (_loadExtParamsWord(extParams) & EXT_PARAMS_FLAG_FEE_DELEGATION) != 0;
+    }
+
+    function _decodeAppendByVirtualsSuffix(
+        bytes calldata extParams
+    ) internal pure returns (bool) {
+        return (_loadExtParamsWord(extParams) & EXT_PARAMS_FLAG_SKIP_SUFFIX) == 0;
     }
 
     function initialize(
@@ -191,9 +202,8 @@ contract BondingV5 is
         bondingConfig = BondingConfig(bondingConfig_);
     }
 
-    /// @param extParams_ Optional extension payload. V1: `abi.encode(bool isFeeDelegation)`; use
-    ///         `""` (empty) to default `isFeeDelegation` to false. Future versions may use
-    ///         `abi.encode(bool, ...)`; this function only reads the first bool word.
+    /// @param extParams_ Optional extension payload (first 32 bytes). V1: `abi.encode(bool isFeeDelegation)`.
+    ///         V2: set bit 1 of the word to skip `" by Virtuals"` (bit 1 unset ⇒ append). Use `""` for defaults.
     function preLaunch(
         string memory name_,
         string memory ticker_,
@@ -293,7 +303,7 @@ contract BondingV5 is
         BondingConfig.DeployParams memory configDeployParams = bondingConfig
             .getDeployParams();
 
-        string memory tokenName = string.concat(name_, " by Virtuals");
+        string memory tokenName = _decodeAppendByVirtualsSuffix(extParams_) ? string.concat(name_, " by Virtuals") : name_;
 
         (address token, uint256 applicationId) = agentFactory
             .createNewAgentTokenAndApplication(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes bonding launch tax behavior for tokens that select the new type; impact is localized to config helpers but affects live swap tax calculation via the router.
> 
> **Overview**
> Adds a new launch anti-sniper option **`ANTI_SNIPER_8M` (type 5)**: **buy-only** protection for **480 seconds (8 minutes)**, with tax ramping from 99% down to 0% like the existing buy-side modes.
> 
> `BondingConfig` is updated so type 5 is accepted in **`isValidAntiSniperType`**, treated as buy-side in **`appliesAntiSniperOnBuy`** (sells unchanged), and returns **480** from **`getAntiSniperDuration`**. NatSpec for the anti-sniper helpers documents the new variant.
> 
> Callers such as **`FRouterV3`** that already read duration and buy/sell flags from config will pick up the new type without further contract changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ad3626e0c56d3c42581b96b8b1ea62174028fe3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->